### PR TITLE
SyslogLayout - Use Rfc5424 by default, so StructuredDataParams works out of the box

### DIFF
--- a/src/NLog.Targets.Network/Layouts/SyslogLayout.cs
+++ b/src/NLog.Targets.Network/Layouts/SyslogLayout.cs
@@ -255,13 +255,13 @@ namespace NLog.Layouts
             var appName = _appNameString ?? EscapePropertyName(SyslogAppName?.Render(logEvent) ?? string.Empty, AppNameMaxLength);
             var processId = _processIdString ?? EscapePropertyName(SyslogProcessId?.Render(logEvent) ?? string.Empty, ProcessIdMaxLength);
 
-            if (Rfc3164 || !Rfc5424)
+            if (Rfc5424 || !Rfc3164)
             {
-                Render_Rfc3164(logEvent, target, priValue, hostName, appName, processId);
+                Render_Rfc5424(logEvent, target, priValue, hostName, appName, processId);
             }
             else
             {
-                Render_Rfc5424(logEvent, target, priValue, hostName, appName, processId);
+                Render_Rfc3164(logEvent, target, priValue, hostName, appName, processId);
             }
         }
 

--- a/tests/NLog.Targets.Network.Tests/SyslogLayoutTests.cs
+++ b/tests/NLog.Targets.Network.Tests/SyslogLayoutTests.cs
@@ -55,7 +55,7 @@ namespace NLog.Targets.Network
         [Fact]
         public void SyslogLayout_Rfc3164()
         {
-            var memTarget = new NLog.Targets.MemoryTarget() { Layout = new SyslogLayout() };
+            var memTarget = new NLog.Targets.MemoryTarget() { Layout = new SyslogLayout() { Rfc3164 = true } };
             using (var logFactory = new LogFactory().Setup().LoadConfiguration(cfg => cfg.ForLogger().WriteTo(memTarget)).LogFactory)
             {
                 var logger = logFactory.GetCurrentClassLogger();
@@ -73,7 +73,7 @@ namespace NLog.Targets.Network
         [Fact]
         public void SyslogLayout_Rfc3164_Newline()
         {
-            var memTarget = new NLog.Targets.MemoryTarget() { Layout = new SyslogLayout() };
+            var memTarget = new NLog.Targets.MemoryTarget() { Layout = new SyslogLayout() { Rfc3164 = true } };
             using (var logFactory = new LogFactory().Setup().LoadConfiguration(cfg => cfg.ForLogger().WriteTo(memTarget)).LogFactory)
             {
                 var logger = logFactory.GetCurrentClassLogger();
@@ -97,7 +97,7 @@ namespace NLog.Targets.Network
         [InlineData("Fatal", "<136>")]
         public void SyslogLayout_Rfc3164_LogLevels(string logLevel, string priValue)
         {
-            var memTarget = new NLog.Targets.MemoryTarget() { Layout = new SyslogLayout() { SyslogFacility = SyslogFacility.Local1 } };
+            var memTarget = new NLog.Targets.MemoryTarget() { Layout = new SyslogLayout() { Rfc3164 = true, SyslogFacility = SyslogFacility.Local1 } };
             using (var logFactory = new LogFactory().Setup().LoadConfiguration(cfg => cfg.ForLogger().WriteTo(memTarget)).LogFactory)
             {
                 var logger = logFactory.GetCurrentClassLogger();
@@ -115,7 +115,7 @@ namespace NLog.Targets.Network
         [Fact]
         public void SyslogLayout_Rfc3164_EscapeNames()
         {
-            var memTarget = new NLog.Targets.MemoryTarget() { Layout = new SyslogLayout() { SyslogHostName = " Hello World ", SyslogAppName = " Destroy World ", SyslogProcessId = " Goodbye World " } };
+            var memTarget = new NLog.Targets.MemoryTarget() { Layout = new SyslogLayout() { Rfc3164 = true, SyslogHostName = " Hello World ", SyslogAppName = " Destroy World ", SyslogProcessId = " Goodbye World " } };
             using (var logFactory = new LogFactory().Setup().LoadConfiguration(cfg => cfg.ForLogger().WriteTo(memTarget)).LogFactory)
             {
                 var logger = logFactory.GetCurrentClassLogger();
@@ -133,7 +133,7 @@ namespace NLog.Targets.Network
         [Fact]
         public void SyslogLayout_Rfc5424()
         {
-            var memTarget = new NLog.Targets.MemoryTarget() { Layout = new SyslogLayout() { Rfc5424 = true } };
+            var memTarget = new NLog.Targets.MemoryTarget() { Layout = new SyslogLayout() };
             using (var logFactory = new LogFactory().Setup().LoadConfiguration(cfg => cfg.ForLogger().WriteTo(memTarget)).LogFactory)
             {
                 var logger = logFactory.GetCurrentClassLogger();
@@ -148,7 +148,7 @@ namespace NLog.Targets.Network
         [Fact]
         public void SyslogLayout_Rfc5424_Newline()
         {
-            var memTarget = new NLog.Targets.MemoryTarget() { Layout = new SyslogLayout() { Rfc5424 = true } };
+            var memTarget = new NLog.Targets.MemoryTarget() { Layout = new SyslogLayout() };
             using (var logFactory = new LogFactory().Setup().LoadConfiguration(cfg => cfg.ForLogger().WriteTo(memTarget)).LogFactory)
             {
                 var logger = logFactory.GetCurrentClassLogger();
@@ -169,7 +169,7 @@ namespace NLog.Targets.Network
         [InlineData("Fatal", "<136>")]
         public void SyslogLayout_Rfc5424_LogLevels(string logLevel, string priValue)
         {
-            var memTarget = new NLog.Targets.MemoryTarget() { Layout = new SyslogLayout() { Rfc5424 = true, SyslogFacility = SyslogFacility.Local1 } };
+            var memTarget = new NLog.Targets.MemoryTarget() { Layout = new SyslogLayout() { SyslogFacility = SyslogFacility.Local1 } };
             using (var logFactory = new LogFactory().Setup().LoadConfiguration(cfg => cfg.ForLogger().WriteTo(memTarget)).LogFactory)
             {
                 var logger = logFactory.GetCurrentClassLogger();
@@ -184,7 +184,7 @@ namespace NLog.Targets.Network
         [Fact]
         public void SyslogLayout_Rfc5424_EscapeNames()
         {
-            var memTarget = new NLog.Targets.MemoryTarget() { Layout = new SyslogLayout() { Rfc5424 = true } };
+            var memTarget = new NLog.Targets.MemoryTarget() { Layout = new SyslogLayout() };
             using (var logFactory = new LogFactory().Setup().LoadConfiguration(cfg => cfg.ForLogger().WriteTo(memTarget)).LogFactory)
             {
                 var logger = logFactory.GetCurrentClassLogger();
@@ -199,7 +199,7 @@ namespace NLog.Targets.Network
         [Fact]
         public void SyslogLayout_Rfc5424_StructuredData()
         {
-            var syslogLayout = new SyslogLayout() { Rfc5424 = true };
+            var syslogLayout = new SyslogLayout();
             syslogLayout.StructuredDataParams.Add(new TargetPropertyWithContext(" ThreadId ", " ${threadid} "));
             syslogLayout.IncludeEventProperties = true;
 


### PR DESCRIPTION
Like that `IncludeEventProperties` + `StructuredDataParams` just works without extra settings.

- [ ] Wait for NLog.Targets.Network v6.1