### PR TITLE
OtlpBatchBuilder with same ResourceAttributes for entire batch

### DIFF
--- a/src/NLog.Targets.HttpClient/NLog.Targets.HttpClient.csproj
+++ b/src/NLog.Targets.HttpClient/NLog.Targets.HttpClient.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net471;netstandard2.0;netstandard2.1</TargetFrameworks>
 
     <VersionPrefix>6.0.5</VersionPrefix>
-    <VersionSuffix>Preview1</VersionSuffix>
+    <VersionSuffix>Preview2</VersionSuffix>
     <AssemblyVersion>6.0.0.0</AssemblyVersion>
     <!-- Strong AssemblyVersion must be fixed on 6.0.0.0 -->
     <AppVeyorBuildNumber>$(APPVEYOR_BUILD_NUMBER)</AppVeyorBuildNumber>
@@ -25,7 +25,7 @@
     <PackageReleaseNotes>
 Changelog:
 
-- Preview1 Release of HttpClientTarget.
+- Preview2 Release of HttpClientTarget.
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>NLog;HTTP;HTTPS;HttpClient;logging;log</PackageTags>

--- a/src/NLog.Targets.OpenTelemetryHttp/Internal/OtlpBatchBuilder.cs
+++ b/src/NLog.Targets.OpenTelemetryHttp/Internal/OtlpBatchBuilder.cs
@@ -56,45 +56,69 @@ namespace NLog.Internal
         /// <summary>
         /// Resource attributes must be added before first log record.
         /// </summary>
-        public void AddResourceAttribute(string name, string value)
+        public void AddResourcePayload(KeyValuePair<byte[], byte[]> cachedResourcePayload)
         {
             if (_resourceClosed)
-                throw new InvalidOperationException("Cannot add resource attributes after first log record.");
+                throw new InvalidOperationException("Resource payload already initialized.");
 
-            OtlpProtobufSerializer.WriteKeyStringValue(_stream, 1, name, value);
-        }
+            // Key = Resource payload
+            _stream.Write(cachedResourcePayload.Key, 0, cachedResourcePayload.Key.Length);
 
-        /// <summary>
-        /// Ensures ScopeLogs exists (created lazily on first log record).
-        /// </summary>
-        private void EnsureScopeLogs(string scopeName)
-        {
-            if (_scopeLogsWriter != null)
-                return;
-
-            // Close resource section BEFORE entering scope_logs
             _resourceClosed = true;
             _resourceWriter.Dispose();
 
             // ResourceLogs.scope_logs (field 2)
             _scopeLogsWriter = OtlpProtobufSerializer.BeginSubmessageField(_stream, 2);
 
-            // ScopeLogs.scope (field 1)
+            // Value = ScopeLogs payload
+            _stream.Write(cachedResourcePayload.Value, 0, cachedResourcePayload.Value.Length);
+        }
+
+        internal static KeyValuePair<byte[], byte[]> CreateResourcePayload(string scopeName, IEnumerable<KeyValuePair<string, string>> resourceAttributes)
+        {
+            // Resource payload contents
+            using var resourceStream = new MemoryStream();
+
+            foreach (var resourceAttribute in resourceAttributes)
+            {
+                if (string.IsNullOrEmpty(resourceAttribute.Key))
+                    continue;
+
+                OtlpProtobufSerializer.WriteKeyStringValue(
+                    resourceStream,
+                    1,
+                    resourceAttribute.Key,
+                    resourceAttribute.Value ?? string.Empty);
+            }
+
+            // ScopeLogs payload contents
+            using var scopeLogsStream = new MemoryStream();
+
             if (!string.IsNullOrEmpty(scopeName))
             {
-                using (OtlpProtobufSerializer.BeginSubmessageField(_stream, 1))
+                // InstrumentationScope scope = 1
+                using (OtlpProtobufSerializer.BeginSubmessageField(scopeLogsStream, 1))
                 {
-                    OtlpProtobufSerializer.WriteStringField(_stream, 1, scopeName);
+                    // InstrumentationScope.name = 1
+                    OtlpProtobufSerializer.WriteStringField(
+                        scopeLogsStream,
+                        1,
+                        scopeName);
                 }
             }
+
+            return new KeyValuePair<byte[], byte[]>(
+                resourceStream.ToArray(),   // Key = Resource payload
+                scopeLogsStream.ToArray()); // Value = ScopeLogs payload
         }
 
         /// <summary>
         /// Writes a single OTLP LogRecord.
         /// </summary>
-        public void AddLogRecord<T>(string scopeName, LogEventInfo logEvent, string logMessage, IEnumerable<KeyValuePair<T, object?>>? properties)
+        public void AddLogRecord<T>(LogEventInfo logEvent, string logMessage, IEnumerable<KeyValuePair<T, object?>>? properties)
         {
-            EnsureScopeLogs(scopeName);
+            if (_scopeLogsWriter is null)
+                throw new InvalidOperationException("Cannot add log record before initializing scope logs.");
 
             // ScopeLogs.log_records (field 2)
             using (OtlpProtobufSerializer.BeginSubmessageField(_stream, 2))

--- a/src/NLog.Targets.OpenTelemetryHttp/Internal/OtlpBatchBuilder.cs
+++ b/src/NLog.Targets.OpenTelemetryHttp/Internal/OtlpBatchBuilder.cs
@@ -31,18 +31,12 @@ namespace NLog.Internal
 
         private OtlpProtobufSerializer.SubmessageWriter? _scopeLogsWriter;
 
-        private bool _resourceClosed;
-        private bool _disposed;
-
         internal OtlpBatchBuilder(
             OtlpProtobufSerializer serializer,
             MemoryStream stream)
         {
             _serializer = serializer;
             _stream = stream;
-
-            _disposed = false;
-            _resourceClosed = false;
 
             // ExportLogsServiceRequest.ResourceLogs
             _resourceLogsWriter = OtlpProtobufSerializer.BeginSubmessageField(stream, 1);
@@ -58,13 +52,12 @@ namespace NLog.Internal
         /// </summary>
         public void AddResourcePayload(KeyValuePair<byte[], byte[]> cachedResourcePayload)
         {
-            if (_resourceClosed)
+            if (_scopeLogsWriter != null)
                 throw new InvalidOperationException("Resource payload already initialized.");
 
             // Key = Resource payload
             _stream.Write(cachedResourcePayload.Key, 0, cachedResourcePayload.Key.Length);
 
-            _resourceClosed = true;
             _resourceWriter.Dispose();
 
             // ResourceLogs.scope_logs (field 2)
@@ -74,7 +67,7 @@ namespace NLog.Internal
             _stream.Write(cachedResourcePayload.Value, 0, cachedResourcePayload.Value.Length);
         }
 
-        internal static KeyValuePair<byte[], byte[]> CreateResourcePayload(string scopeName, IEnumerable<KeyValuePair<string, string>> resourceAttributes)
+        internal static KeyValuePair<byte[], byte[]> CreateResourcePayload(string scopeName, IEnumerable<KeyValuePair<string, object>> resourceAttributes)
         {
             // Resource payload contents
             using var resourceStream = new MemoryStream();
@@ -84,7 +77,7 @@ namespace NLog.Internal
                 if (string.IsNullOrEmpty(resourceAttribute.Key))
                     continue;
 
-                OtlpProtobufSerializer.WriteKeyStringValue(
+                OtlpProtobufSerializer.WriteKeyValue(
                     resourceStream,
                     1,
                     resourceAttribute.Key,
@@ -130,26 +123,19 @@ namespace NLog.Internal
         /// <summary>
         /// Finalizes protobuf structure.
         /// </summary>
-        public void Dispose()
+        public void Complete()
         {
-            if (_disposed)
-                return;
+            if (_scopeLogsWriter == null)
+                throw new InvalidOperationException("Completed but without adding ScopeLogs.");
 
-            _disposed = true;
-
-            // Close scope logs first (if opened)
+            // Close scope logs
             _scopeLogsWriter?.Dispose();
             _scopeLogsWriter = null;
-
-            // Resource already closed when scope started, but safe to ensure
-            if (!_resourceClosed)
-            {
-                _resourceWriter.Dispose();
-                _resourceClosed = true;
-            }
 
             // Close ResourceLogs and outer request
             _resourceLogsWriter.Dispose();
         }
+
+        public void Dispose() => Complete();
     }
 }

--- a/src/NLog.Targets.OpenTelemetryHttp/Internal/OtlpBatchBuilder.cs
+++ b/src/NLog.Targets.OpenTelemetryHttp/Internal/OtlpBatchBuilder.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace NLog.Internal
+{
+    /// <summary>
+    /// Builds an OTLP <c>ExportLogsServiceRequest</c> containing a single <c>ResourceLogs</c> entry.
+    /// All log records in the batch share the same resource context (e.g., <c>service.name</c> and resource attributes).
+    /// </summary>
+    /// <remarks>
+    /// The resulting OTLP structure is:
+    /// <code>
+    /// ExportLogsServiceRequest
+    /// └── ResourceLogs
+    ///     ├── Resource (service + attributes)
+    ///     └── ScopeLogs
+    ///         └── LogRecords
+    /// </code>
+    /// </remarks>
+    internal struct OtlpBatchBuilder : IDisposable
+    {
+        private readonly OtlpProtobufSerializer _serializer;
+        private readonly MemoryStream _stream;
+
+        // ExportLogsServiceRequest → ResourceLogs (field 1)
+        private OtlpProtobufSerializer.SubmessageWriter _resourceLogsWriter;
+
+        // ResourceLogs → Resource (field 1)
+        private OtlpProtobufSerializer.SubmessageWriter _resourceWriter;
+
+        private OtlpProtobufSerializer.SubmessageWriter? _scopeLogsWriter;
+
+        private bool _resourceClosed;
+        private bool _disposed;
+
+        internal OtlpBatchBuilder(
+            OtlpProtobufSerializer serializer,
+            MemoryStream stream)
+        {
+            _serializer = serializer;
+            _stream = stream;
+
+            _disposed = false;
+            _resourceClosed = false;
+
+            // ExportLogsServiceRequest.ResourceLogs
+            _resourceLogsWriter = OtlpProtobufSerializer.BeginSubmessageField(stream, 1);
+
+            // ResourceLogs.Resource
+            _resourceWriter = OtlpProtobufSerializer.BeginSubmessageField(stream, 1);
+
+            _scopeLogsWriter = null;
+        }
+
+        /// <summary>
+        /// Resource attributes must be added before first log record.
+        /// </summary>
+        public void AddResourceAttribute(string name, string value)
+        {
+            if (_resourceClosed)
+                throw new InvalidOperationException("Cannot add resource attributes after first log record.");
+
+            OtlpProtobufSerializer.WriteKeyStringValue(_stream, 1, name, value);
+        }
+
+        /// <summary>
+        /// Ensures ScopeLogs exists (created lazily on first log record).
+        /// </summary>
+        private void EnsureScopeLogs(string scopeName)
+        {
+            if (_scopeLogsWriter != null)
+                return;
+
+            // Close resource section BEFORE entering scope_logs
+            _resourceClosed = true;
+            _resourceWriter.Dispose();
+
+            // ResourceLogs.scope_logs (field 2)
+            _scopeLogsWriter = OtlpProtobufSerializer.BeginSubmessageField(_stream, 2);
+
+            // ScopeLogs.scope (field 1)
+            if (!string.IsNullOrEmpty(scopeName))
+            {
+                using (OtlpProtobufSerializer.BeginSubmessageField(_stream, 1))
+                {
+                    OtlpProtobufSerializer.WriteStringField(_stream, 1, scopeName);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Writes a single OTLP LogRecord.
+        /// </summary>
+        public void AddLogRecord<T>(string scopeName, LogEventInfo logEvent, string logMessage, IEnumerable<KeyValuePair<T, object?>>? properties)
+        {
+            EnsureScopeLogs(scopeName);
+
+            // ScopeLogs.log_records (field 2)
+            using (OtlpProtobufSerializer.BeginSubmessageField(_stream, 2))
+            {
+                _serializer.BuildLogRecord(_stream, logEvent, logMessage, properties);
+            }
+        }
+
+        /// <summary>
+        /// Finalizes protobuf structure.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+
+            // Close scope logs first (if opened)
+            _scopeLogsWriter?.Dispose();
+            _scopeLogsWriter = null;
+
+            // Resource already closed when scope started, but safe to ensure
+            if (!_resourceClosed)
+            {
+                _resourceWriter.Dispose();
+                _resourceClosed = true;
+            }
+
+            // Close ResourceLogs and outer request
+            _resourceLogsWriter.Dispose();
+        }
+    }
+}

--- a/src/NLog.Targets.OpenTelemetryHttp/Internal/OtlpProtobufSerializer.cs
+++ b/src/NLog.Targets.OpenTelemetryHttp/Internal/OtlpProtobufSerializer.cs
@@ -181,38 +181,38 @@ namespace NLog.Internal
         {
             private readonly OtlpProtobufSerializer _serializer;
             private readonly MemoryStream _stream;
-            private readonly SubmessageWriter _requestWriter;
+            private readonly SubmessageWriter _resourceLogsWriter;
             private readonly SubmessageWriter _resourceWriter;
-            private SubmessageWriter? _scopeWriter;
+            private SubmessageWriter? _scopeLogsWriter;
 
             internal OtlpLogRecordBuilder(OtlpProtobufSerializer serializer, MemoryStream stream)
             {
                 _serializer = serializer;
                 _stream = stream;
 
-                // ExportLogsServiceRequest { repeated ResourceLogs resource_logs = 1 }
-                _requestWriter = BeginSubmessageField(stream, 1);
-                // ResourceLogs { Resource resource = 1; repeated ScopeLogs scope_logs = 2 }
+                // ExportLogsServiceRequest.ResourceLogs
+                _resourceLogsWriter = BeginSubmessageField(stream, 1);
+                // ResourceLogs.Resource
                 _resourceWriter = BeginSubmessageField(stream, 1);
-                _scopeWriter = null;
+                _scopeLogsWriter = null;
             }
 
-            public void AddResourceAttribute(string key, string value)
+            public void AddResourceAttribute(string key, object value)
             {
-                if (_scopeWriter != null)
+                if (_scopeLogsWriter != null)
                     throw new InvalidOperationException("Cannot add Resource attributes after ScopeLogs has started.");
-                WriteKeyStringValue(_stream, 1, key, value);
+                WriteKeyValue(_stream, 1, key, value);
             }
 
             public void BeginScope(string scopeName)
             {
-                if (_scopeWriter != null)
+                if (_scopeLogsWriter != null)
                     throw new InvalidOperationException("Only one ScopeLogs is supported per builder.");
 
                 _resourceWriter.Dispose();  // Ensure Resource is closed before starting ScopeLogs
 
                 // ScopeLogs { InstrumentationScope scope = 1; repeated LogRecord log_records = 2 }
-                _scopeWriter = BeginSubmessageField(_stream, 2);
+                _scopeLogsWriter = BeginSubmessageField(_stream, 2);
                 if (!string.IsNullOrEmpty(scopeName))
                 {
                     // InstrumentationScope { string name = 1; string version = 2 }
@@ -225,7 +225,7 @@ namespace NLog.Internal
 
             public void AddLogRecord<T>(LogEventInfo logEvent, string logMessage, IEnumerable<KeyValuePair<T, object?>>? logProperties)
             {
-                if (_scopeWriter == null)
+                if (_scopeLogsWriter == null)
                     throw new InvalidOperationException("ScopeLogs must be started before adding LogRecords.");
 
                 using (BeginSubmessageField(_stream, 2))
@@ -236,12 +236,12 @@ namespace NLog.Internal
 
             public void Complete()
             {
-                if (_scopeWriter == null)
+                if (_scopeLogsWriter == null)
                     throw new InvalidOperationException("Completed but without adding ScopeLogs.");
 
-                _scopeWriter?.Dispose();
-                _scopeWriter = null;
-                _requestWriter.Dispose();
+                _scopeLogsWriter?.Dispose();
+                _scopeLogsWriter = null;
+                _resourceLogsWriter.Dispose();
             }
 
             public void Dispose() => Complete();
@@ -478,7 +478,7 @@ namespace NLog.Internal
             }
         }
 
-        internal static void WriteKeyStringValue(MemoryStream parent, int fieldNumber, string key, string value)
+        private static void WriteKeyStringValue(MemoryStream parent, int fieldNumber, string key, string value)
         {
             // KeyValue { string key = 1; AnyValue value = 2 }
             var keyMaxBytes = Encoding.UTF8.GetMaxByteCount(key.Length);
@@ -491,7 +491,7 @@ namespace NLog.Internal
             }
         }
 
-        private static void WriteKeyValue(MemoryStream parent, int fieldNumber, string key, object? value, int recursionDepth = 0)
+        internal static void WriteKeyValue(MemoryStream parent, int fieldNumber, string key, object? value, int recursionDepth = 0)
         {
             if (value is string stringValue)
             {
@@ -511,7 +511,7 @@ namespace NLog.Internal
             }
         }
 
-        internal static void WriteVarint(MemoryStream stream, ulong value)
+        private static void WriteVarint(MemoryStream stream, ulong value)
         {
             while (value > 0x7F)
             {
@@ -521,7 +521,7 @@ namespace NLog.Internal
             stream.WriteByte((byte)value);
         }
 
-        internal static void WriteTag(MemoryStream stream, int fieldNumber, int wireType)
+        private static void WriteTag(MemoryStream stream, int fieldNumber, int wireType)
         {
             WriteVarint(stream, (ulong)((fieldNumber << 3) | wireType));
         }
@@ -778,7 +778,7 @@ namespace NLog.Internal
             return utcTicks > 0 ? (ulong)utcTicks * 100UL : 0UL;
         }
 
-        internal static int MapSeverityNumber(LogLevel? level)
+        private static int MapSeverityNumber(LogLevel? level)
         {
             if (level == LogLevel.Trace) return 1;   // SEVERITY_NUMBER_TRACE
             if (level == LogLevel.Debug) return 5;   // SEVERITY_NUMBER_DEBUG

--- a/src/NLog.Targets.OpenTelemetryHttp/Internal/OtlpProtobufSerializer.cs
+++ b/src/NLog.Targets.OpenTelemetryHttp/Internal/OtlpProtobufSerializer.cs
@@ -76,28 +76,6 @@ namespace NLog.Internal
         }
 
         /// <summary>
-        /// Builds a ScopeLogs protobuf message containing the instrumentation scope and a single log record.
-        /// </summary>
-        private void BuildScopeLogs<T>(MemoryStream stream, string scopeName, LogEventInfo logEvent, string logMessage, IEnumerable<KeyValuePair<T, object?>>? logProperties)
-        {
-            // ScopeLogs { InstrumentationScope scope = 1; repeated LogRecord log_records = 2 }
-            if (!string.IsNullOrEmpty(scopeName))
-            {
-                // InstrumentationScope { string name = 1; string version = 2 }
-                var scopeNameMaxBytes = Encoding.UTF8.GetMaxByteCount(scopeName.Length);
-                using (BeginSubmessageField(stream, 1, scopeNameMaxBytes))
-                {
-                    WriteStringField(stream, 1, scopeName, scopeNameMaxBytes);
-                }
-            }
-
-            using (BeginSubmessageField(stream, 2))
-            {
-                BuildLogRecord(stream, logEvent, logMessage, logProperties);
-            }
-        }
-
-        /// <summary>
         /// Builds a LogRecord protobuf message for a single log event.
         /// </summary>
         internal void BuildLogRecord<T>(MemoryStream stream, LogEventInfo logEvent, string logMessage, IEnumerable<KeyValuePair<T, object?>>? logProperties)
@@ -120,7 +98,6 @@ namespace NLog.Internal
                 WriteStringField(stream, 3, logEvent.Level.ToString());
             }
 
-            // body = AnyValue { string string_value = 1 }
             if (!string.IsNullOrEmpty(logMessage))
             {
                 BuildAnyValueString(stream, 5, logMessage);
@@ -128,8 +105,9 @@ namespace NLog.Internal
 
             if (!string.IsNullOrEmpty(logEvent.LoggerName))
             {
-                WriteKeyStringValue(stream, 6, "LoggerName", logEvent.LoggerName);
+                WriteKeyStringValue(stream, 6, "logger.name", logEvent.LoggerName);
             }
+
 
             if (logEvent.Exception != null)
             {
@@ -140,6 +118,24 @@ namespace NLog.Internal
 
             if (logProperties != null)
             {
+                string eventId = string.Empty;
+                string eventName = string.Empty;
+
+                if (logEvent.HasProperties)
+                {
+                    WriteKeyStringValue(stream, 6, "log.record.original", logEvent.Message);    // Message Template with placeholders
+                    if (logEvent.Properties.TryGetValue("EventId", out var eventIdObj) && eventIdObj != null)
+                    {
+                        eventId = "EventId";
+                        WriteKeyValue(stream, 6, "event.id", eventIdObj);
+                    }
+                    if (logEvent.Properties.TryGetValue("EventName", out var eventNameObj) && eventNameObj != null)
+                    {
+                        eventName = "EventName";
+                        WriteKeyValue(stream, 6, "event.name", eventNameObj);
+                    }
+                }
+
                 var enumerator = logProperties.GetEnumerator();
                 try
                 {
@@ -148,6 +144,11 @@ namespace NLog.Internal
                         var prop = enumerator.Current;
                         var key = prop.Key?.ToString();
                         if (key is null || string.IsNullOrEmpty(key))
+                            continue;
+
+                        if (!ReferenceEquals(eventId, string.Empty) && key == eventId)
+                            continue;
+                        if (!ReferenceEquals(eventName, string.Empty) && key == eventName)
                             continue;
 
                         WriteKeyValue(stream, 6, key, prop.Value);
@@ -182,52 +183,67 @@ namespace NLog.Internal
             private readonly MemoryStream _stream;
             private readonly SubmessageWriter _requestWriter;
             private readonly SubmessageWriter _resourceWriter;
-            private bool _completed;
+            private SubmessageWriter? _scopeWriter;
 
             internal OtlpLogRecordBuilder(OtlpProtobufSerializer serializer, MemoryStream stream)
             {
                 _serializer = serializer;
                 _stream = stream;
-                _completed = false;
 
                 // ExportLogsServiceRequest { repeated ResourceLogs resource_logs = 1 }
                 _requestWriter = BeginSubmessageField(stream, 1);
-                // ResourceLogs { Resource resource = 1; ... }
+                // ResourceLogs { Resource resource = 1; repeated ScopeLogs scope_logs = 2 }
                 _resourceWriter = BeginSubmessageField(stream, 1);
+                _scopeWriter = null;
             }
 
-            /// <summary>Writes a resource attribute KeyValue into the open Resource submessage.</summary>
-            public void AddResourceAttribute(string attributeName, string attributeValue)
+            public void AddResourceAttribute(string key, string value)
             {
-                WriteKeyStringValue(_stream, 1, attributeName, attributeValue);
+                if (_scopeWriter != null)
+                    throw new InvalidOperationException("Cannot add Resource attributes after ScopeLogs has started.");
+                WriteKeyStringValue(_stream, 1, key, value);
             }
 
-            /// <summary>Closes the Resource submessage, writes ScopeLogs, and finalizes the OTLP message.</summary>
-            public void AddScopeLogs<T>(string scopeName, LogEventInfo logEvent, string logMessage, IEnumerable<KeyValuePair<T, object?>>? logProperties = null)
+            public void BeginScope(string scopeName)
             {
-                if (_completed) return;
-                _completed = true;
+                if (_scopeWriter != null)
+                    throw new InvalidOperationException("Only one ScopeLogs is supported per builder.");
 
-                _resourceWriter.Dispose();
+                _resourceWriter.Dispose();  // Ensure Resource is closed before starting ScopeLogs
 
-                // ResourceLogs { ... repeated ScopeLogs scope_logs = 2 }
+                // ScopeLogs { InstrumentationScope scope = 1; repeated LogRecord log_records = 2 }
+                _scopeWriter = BeginSubmessageField(_stream, 2);
+                if (!string.IsNullOrEmpty(scopeName))
+                {
+                    // InstrumentationScope { string name = 1; string version = 2 }
+                    using (BeginSubmessageField(_stream, 1))
+                    {
+                        WriteStringField(_stream, 1, scopeName);
+                    }
+                }
+            }
+
+            public void AddLogRecord<T>(LogEventInfo logEvent, string logMessage, IEnumerable<KeyValuePair<T, object?>>? logProperties)
+            {
+                if (_scopeWriter == null)
+                    throw new InvalidOperationException("ScopeLogs must be started before adding LogRecords.");
+
                 using (BeginSubmessageField(_stream, 2))
                 {
-                    _serializer.BuildScopeLogs(_stream, scopeName, logEvent, logMessage, logProperties);
+                    _serializer.BuildLogRecord(_stream, logEvent, logMessage, logProperties);
                 }
-
-                _requestWriter.Dispose();
             }
 
             public void Complete()
             {
-                if (_completed) return;
-                _completed = true;
-                _resourceWriter.Dispose();
+                if (_scopeWriter == null)
+                    throw new InvalidOperationException("Completed but without adding ScopeLogs.");
+
+                _scopeWriter?.Dispose();
+                _scopeWriter = null;
                 _requestWriter.Dispose();
             }
 
-            /// <inheritdoc cref="Complete"/>
             public void Dispose() => Complete();
         }
 

--- a/src/NLog.Targets.OpenTelemetryHttp/Internal/OtlpProtobufSerializer.cs
+++ b/src/NLog.Targets.OpenTelemetryHttp/Internal/OtlpProtobufSerializer.cs
@@ -70,6 +70,11 @@ namespace NLog.Internal
             return new OtlpLogRecordBuilder(this, output);
         }
 
+        public OtlpBatchBuilder BeginBatch(MemoryStream output)
+        {
+            return new OtlpBatchBuilder(this, output);
+        }
+
         /// <summary>
         /// Builds a ScopeLogs protobuf message containing the instrumentation scope and a single log record.
         /// </summary>
@@ -95,7 +100,7 @@ namespace NLog.Internal
         /// <summary>
         /// Builds a LogRecord protobuf message for a single log event.
         /// </summary>
-        private void BuildLogRecord<T>(MemoryStream stream, LogEventInfo logEvent, string logMessage, IEnumerable<KeyValuePair<T, object?>>? logProperties)
+        internal void BuildLogRecord<T>(MemoryStream stream, LogEventInfo logEvent, string logMessage, IEnumerable<KeyValuePair<T, object?>>? logProperties)
         {
             // LogRecord proto field numbers:
             //   fixed64 time_unix_nano = 1
@@ -457,7 +462,7 @@ namespace NLog.Internal
             }
         }
 
-        private static void WriteKeyStringValue(MemoryStream parent, int fieldNumber, string key, string value)
+        internal static void WriteKeyStringValue(MemoryStream parent, int fieldNumber, string key, string value)
         {
             // KeyValue { string key = 1; AnyValue value = 2 }
             var keyMaxBytes = Encoding.UTF8.GetMaxByteCount(key.Length);
@@ -490,7 +495,7 @@ namespace NLog.Internal
             }
         }
 
-        private static void WriteVarint(MemoryStream stream, ulong value)
+        internal static void WriteVarint(MemoryStream stream, ulong value)
         {
             while (value > 0x7F)
             {
@@ -500,7 +505,7 @@ namespace NLog.Internal
             stream.WriteByte((byte)value);
         }
 
-        private static void WriteTag(MemoryStream stream, int fieldNumber, int wireType)
+        internal static void WriteTag(MemoryStream stream, int fieldNumber, int wireType)
         {
             WriteVarint(stream, (ulong)((fieldNumber << 3) | wireType));
         }
@@ -528,7 +533,7 @@ namespace NLog.Internal
 #endif
         }
 
-        private static void WriteStringField(MemoryStream stream, int fieldNumber, string value)
+        internal static void WriteStringField(MemoryStream stream, int fieldNumber, string value)
         {
             WriteStringField(stream, fieldNumber, value, Encoding.UTF8.GetMaxByteCount(value.Length));
         }
@@ -619,12 +624,12 @@ namespace NLog.Internal
         }
 #endif
 
-        private static SubmessageWriter BeginSubmessageField(MemoryStream stream, int fieldNumber, int maxByteCount = int.MaxValue)
+        internal static SubmessageWriter BeginSubmessageField(MemoryStream stream, int fieldNumber, int maxByteCount = int.MaxValue)
         {
             return new SubmessageWriter(stream, fieldNumber, maxByteCount);
         }
 
-        private readonly struct SubmessageWriter : IDisposable
+        internal readonly struct SubmessageWriter : IDisposable
         {
             // Protobuf allows non-minimal (padded) varints — decoders must accept them.
             // fixedLength=false reserves 2 bytes (up to 16,383 bytes content) for small leaf nodes.

--- a/src/NLog.Targets.OpenTelemetryHttp/NLog.Targets.OpenTelemetryHttp.csproj
+++ b/src/NLog.Targets.OpenTelemetryHttp/NLog.Targets.OpenTelemetryHttp.csproj
@@ -7,7 +7,7 @@
     <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net471;netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
 
     <VersionPrefix>6.0.5</VersionPrefix>
-    <VersionSuffix>Preview1</VersionSuffix>
+    <VersionSuffix>Preview2</VersionSuffix>
     <AssemblyVersion>6.0.0.0</AssemblyVersion>
     <!-- Strong AssemblyVersion must be fixed on 6.0.0.0 -->
     <AppVeyorBuildNumber>$(APPVEYOR_BUILD_NUMBER)</AppVeyorBuildNumber>
@@ -26,7 +26,7 @@
     <PackageReleaseNotes>
 Changelog:
 
-- Preview1 Release of OpenTelemetryHttpTarget.
+- Preview2 Release of OpenTelemetryHttpTarget.
     </PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>NLog;OpenTelemetry;OTLP;logging;log</PackageTags>

--- a/src/NLog.Targets.OpenTelemetryHttp/OpenTelemetryHttpTarget.cs
+++ b/src/NLog.Targets.OpenTelemetryHttp/OpenTelemetryHttpTarget.cs
@@ -69,8 +69,9 @@ namespace NLog.Targets
     public class OpenTelemetryHttpTarget : HttpClientTarget
     {
         private static readonly SimpleLayout _defaultServiceName = new SimpleLayout("${appdomain:format=Friendly}");
+        private static readonly SimpleLayout _defaultServiceVersion = new SimpleLayout("${assembly-version:Default=}");
+        private static readonly SimpleLayout _defaultHostName = new SimpleLayout("${hostname}");
         private static readonly Layout _defaultOperatingSystem = Layout.FromMethod(static evt => ResolveOperatingSystem(), LayoutRenderOptions.ThreadAgnostic);
-        private static readonly SimpleLayout _defaultProcessId = new SimpleLayout("${processid}");
 
         private static readonly string EmptyTraceIdToHexString = default(System.Diagnostics.ActivityTraceId).ToHexString();
         private static readonly string EmptySpanIdToHexString = default(System.Diagnostics.ActivitySpanId).ToHexString();
@@ -87,12 +88,12 @@ namespace NLog.Targets
         public OpenTelemetryHttpTarget()
         {
             ContentType = "application/x-protobuf"; // application/json not supported, only protobuf as OTLP_PROTOCOL
-            IncludeEventProperties = true;
             BatchSize = 200;                // Consider doubling this if enabling compression
             TaskDelayMilliseconds = 50;     // Small delay to improve chance of batching and reducing number of HTTP requests.
-            RetryDelayMilliseconds = 2500;  // Notice OTel SDK initial backoff is 5 secs
+            RetryDelayMilliseconds = 5000;  // Notice OTel SDK initial backoff is 5 secs
             RetryCount = 3;                 // Notice OTel SDK default max 5 retries
             Layout = "${message}";
+            IncludeEventProperties = true;
         }
 
         /// <summary>
@@ -105,13 +106,13 @@ namespace NLog.Targets
         /// Gets or sets the OTLP resource <c>service.version</c> attribute value.
         /// </summary>
         /// <remarks>Default: <c>${assembly-version:Default=}</c>.</remarks>
-        public Layout ServiceVersion { get; set; } = "${assembly-version:Default=}";
+        public Layout ServiceVersion { get; set; } = _defaultServiceVersion;
 
         /// <summary>
         /// Gets or sets the OTLP resource <c>host.name</c> attribute value.
         /// </summary>
         /// <remarks>Default: <c>${hostname}</c>.</remarks>
-        public Layout HostName { get; set; } = "${hostname}";
+        public Layout HostName { get; set; } = _defaultHostName;
 
         /// <summary>
         /// Gets or sets the OpenTelemetry instrumentation scope name.
@@ -271,13 +272,21 @@ namespace NLog.Targets
             }
         }
 
-        IEnumerable<KeyValuePair<string, string>> GetResourceAttributes(LogEventInfo firstEvent)
+        IEnumerable<KeyValuePair<string, object>> GetResourceAttributes(LogEventInfo firstEvent)
         {
             Layout? serviceNameLayout = ServiceName;
             Layout? serviceVersionLayout = ServiceVersion;
             Layout? hostNameLayout = HostName;
             Layout? operatingSystemLayout = _defaultOperatingSystem;
-            Layout? processIdLayout = _defaultProcessId;
+            int? processId =
+#if NET
+                Environment.ProcessId;
+#else
+                System.Diagnostics.Process.GetCurrentProcess().Id;
+#endif
+            string telemetrySdkLanguage = "dotnet";
+            string telemetrySdkName = typeof(OpenTelemetryHttpTarget).ToString();
+            string telemetrySdkVersion = typeof(OpenTelemetryHttpTarget).Assembly.GetName().Version?.ToString() ?? string.Empty;
 
             for (int j = 0; j < ResourceAttributes.Count; ++j)
             {
@@ -285,21 +294,34 @@ namespace NLog.Targets
                 if (string.IsNullOrWhiteSpace(attr.Name))
                     continue;
 
-                var value = RenderLogEvent(attr.Layout, firstEvent);
-                if (!attr.IncludeEmptyValue && string.IsNullOrWhiteSpace(value))
+                var stringValue = RenderLogEvent(attr.Layout, firstEvent);
+                if (!attr.IncludeEmptyValue && string.IsNullOrWhiteSpace(stringValue))
                     continue;
+
+                object value = stringValue;
 
                 if (attr.Name == "service.name")
                     serviceNameLayout = null;
                 else if (attr.Name == "service.version")
                     serviceVersionLayout = null;
+                else if (attr.Name == "process.id")
+                {
+                    processId = null;
+                    if (long.TryParse(stringValue, out var parsedProcessId))
+                        value = parsedProcessId;
+                }
                 else if (attr.Name == "host.name")
                     hostNameLayout = null;
                 else if (attr.Name == "os.type")
                     operatingSystemLayout = null;
-                else if (attr.Name == "process.id")
-                    processIdLayout = null;
-                yield return new KeyValuePair<string, string>(attr.Name, value);
+                else if (attr.Name == "telemetry.sdk.language")
+                    telemetrySdkLanguage = string.Empty;
+                else if (attr.Name == "telemetry.sdk.name")
+                    telemetrySdkName = string.Empty;
+                else if (attr.Name == "telemetry.sdk.version")
+                    telemetrySdkVersion = string.Empty;
+
+                yield return new KeyValuePair<string, object>(attr.Name, value);
             }
 
             if (serviceNameLayout != null)
@@ -307,32 +329,36 @@ namespace NLog.Targets
                 var serviceName = RenderLogEvent(serviceNameLayout, firstEvent);
                 if (string.IsNullOrEmpty(serviceName))
                     serviceName = "Unknown";
-                yield return new KeyValuePair<string, string>("service.name", serviceName);
+                yield return new KeyValuePair<string, object>("service.name", serviceName);
             }
             if (serviceVersionLayout != null)
             {
                 var serviceVersion = RenderLogEvent(serviceVersionLayout, firstEvent);
                 if (!string.IsNullOrEmpty(serviceVersion))
-                    yield return new KeyValuePair<string, string>("service.version", serviceVersion);
+                    yield return new KeyValuePair<string, object>("service.version", serviceVersion);
             }
-            if (processIdLayout != null)
+            if (processId.HasValue)
             {
-                var processId = RenderLogEvent(processIdLayout, firstEvent);
-                if (!string.IsNullOrEmpty(processId))
-                    yield return new KeyValuePair<string, string>("process.id", processId);
+                yield return new KeyValuePair<string, object>("process.id", processId.Value);
             }
             if (hostNameLayout != null)
             {
                 var hostName = RenderLogEvent(hostNameLayout, firstEvent);
                 if (!string.IsNullOrEmpty(hostName))
-                    yield return new KeyValuePair<string, string>("host.name", hostName);
+                    yield return new KeyValuePair<string, object>("host.name", hostName);
             }
             if (operatingSystemLayout != null)
             {
                 var operatingSystem = RenderLogEvent(operatingSystemLayout, firstEvent);
                 if (!string.IsNullOrEmpty(operatingSystem))
-                    yield return new KeyValuePair<string, string>("os.type", operatingSystem);
+                    yield return new KeyValuePair<string, object>("os.type", operatingSystem);
             }
+            if (!string.IsNullOrEmpty(telemetrySdkLanguage))
+                yield return new KeyValuePair<string, object>("telemetry.sdk.language", telemetrySdkLanguage);
+            if (!string.IsNullOrEmpty(telemetrySdkName))
+                yield return new KeyValuePair<string, object>("telemetry.sdk.name", telemetrySdkName);
+            if (!string.IsNullOrEmpty(telemetrySdkVersion))
+                yield return new KeyValuePair<string, object>("telemetry.sdk.version", telemetrySdkVersion);
         }
 
         private static string ResolveOperatingSystem()
@@ -593,6 +619,16 @@ namespace NLog.Targets
                 {
                     if (ReferenceEquals(ServiceName, _defaultServiceName) && !string.IsNullOrWhiteSpace(value))
                         ServiceName = value;
+                }
+                else if (string.Equals(key, "service.version", StringComparison.Ordinal))
+                {
+                    if (ReferenceEquals(ServiceVersion, _defaultServiceVersion) && !string.IsNullOrWhiteSpace(value))
+                        ServiceVersion = value;
+                }
+                else if (string.Equals(key, "host.name", StringComparison.Ordinal))
+                {
+                    if (ReferenceEquals(HostName, _defaultHostName) && !string.IsNullOrWhiteSpace(value))
+                        HostName = value;
                 }
                 else
                 {

--- a/src/NLog.Targets.OpenTelemetryHttp/OpenTelemetryHttpTarget.cs
+++ b/src/NLog.Targets.OpenTelemetryHttp/OpenTelemetryHttpTarget.cs
@@ -69,10 +69,14 @@ namespace NLog.Targets
     public class OpenTelemetryHttpTarget : HttpClientTarget
     {
         private static readonly SimpleLayout _defaultServiceName = new SimpleLayout("${appdomain:format=Friendly}");
+        private static readonly Layout _defaultOperatingSystem = Layout.FromMethod(static evt => ResolveOperatingSystem(), LayoutRenderOptions.ThreadAgnostic);
+        private static readonly SimpleLayout _defaultProcessId = new SimpleLayout("${processid}");
+
         private static readonly string EmptyTraceIdToHexString = default(System.Diagnostics.ActivityTraceId).ToHexString();
         private static readonly string EmptySpanIdToHexString = default(System.Diagnostics.ActivitySpanId).ToHexString();
 
         private OtlpProtobufSerializer _serializer = new OtlpProtobufSerializer();
+        private KeyValuePair<byte[], byte[]> _cachedResourcePayload;
         private Uri? _logsUrl;
         private readonly Stack<MemoryStream> _memoryStreamPool = new Stack<MemoryStream>();
         private List<MemoryStream>? _activeChunkStreams = new List<MemoryStream>();
@@ -88,6 +92,7 @@ namespace NLog.Targets
             TaskDelayMilliseconds = 50;     // Small delay to improve chance of batching and reducing number of HTTP requests.
             RetryDelayMilliseconds = 2500;  // Notice OTel SDK initial backoff is 5 secs
             RetryCount = 3;                 // Notice OTel SDK default max 5 retries
+            Layout = "${message}";
         }
 
         /// <summary>
@@ -95,6 +100,18 @@ namespace NLog.Targets
         /// </summary>
         /// <remarks>Default: <c>${appdomain:format=Friendly}</c>. Defaults to <c>Unknown</c> when empty value</remarks>
         public Layout ServiceName { get; set; } = _defaultServiceName;
+
+        /// <summary>
+        /// Gets or sets the OTLP resource <c>service.version</c> attribute value.
+        /// </summary>
+        /// <remarks>Default: <c>${assembly-version:Default=}</c>.</remarks>
+        public Layout ServiceVersion { get; set; } = "${assembly-version:Default=}";
+
+        /// <summary>
+        /// Gets or sets the OTLP resource <c>host.name</c> attribute value.
+        /// </summary>
+        /// <remarks>Default: <c>${hostname}</c>.</remarks>
+        public Layout HostName { get; set; } = "${hostname}";
 
         /// <summary>
         /// Gets or sets the OpenTelemetry instrumentation scope name.
@@ -131,6 +148,7 @@ namespace NLog.Targets
                 SpanId = SpanId,
             };
             _logsUrl = null;
+            _cachedResourcePayload = default;
             base.InitializeTarget();
         }
 
@@ -172,7 +190,7 @@ namespace NLog.Targets
             var output = RentMemoryStream();
             chunks.Add(output);
 
-            var batch = CreateNewBatch(output, logEvents[0]);
+            var batch = CreateNewBatch(output);
 
             for (int i = 0; i < logEvents.Count; i++)
             {
@@ -190,8 +208,7 @@ namespace NLog.Targets
 
                     output = RentMemoryStream();
                     chunks.Add(output);
-                    var nextEvent = logEvents[i + 1];
-                    batch = CreateNewBatch(output, nextEvent);
+                    batch = CreateNewBatch(output);
                 }
             }
 
@@ -199,42 +216,30 @@ namespace NLog.Targets
             await SendLastChunkAndAwaitPendingAsync(BuildHttpContent(output), pendingTasks, cancellationToken).ConfigureAwait(false);
         }
 
-        private OtlpBatchBuilder CreateNewBatch(MemoryStream stream, LogEventInfo firstEvent)
+        private OtlpBatchBuilder CreateNewBatch(MemoryStream stream)
         {
-            var batch = _serializer.BeginBatch(stream);
-
-            var serviceName = RenderLogEvent(ServiceName, firstEvent);
-            if (string.IsNullOrWhiteSpace(serviceName))
-                serviceName = "Unknown";
-
-            batch.AddResourceAttribute("service.name", serviceName);
-
-            for (int j = 0; j < ResourceAttributes.Count; ++j)
+            if (_cachedResourcePayload.Key is null)
             {
-                var attr = ResourceAttributes[j];
-                if (string.IsNullOrWhiteSpace(attr.Name))
-                    continue;
-
-                var value = RenderLogEvent(attr.Layout, firstEvent);
-                if (!attr.IncludeEmptyValue && string.IsNullOrWhiteSpace(value))
-                    continue;
-
-                batch.AddResourceAttribute(attr.Name, value);
+                var firstEvent = LogEventInfo.CreateNullEvent();
+                _cachedResourcePayload = OtlpBatchBuilder.CreateResourcePayload(ScopeName, GetResourceAttributes(firstEvent));
             }
 
+            var batch = _serializer.BeginBatch(stream);
+            batch.AddResourcePayload(_cachedResourcePayload);
             return batch;
         }
 
         private void WriteLogRecord(ref OtlpBatchBuilder batch, LogEventInfo logEvent)
         {
+            var logMessage = RenderLogEvent(Layout, logEvent);
             var properties = GetLogEventProperties(logEvent);
             if (properties is null && (IncludeEventProperties && logEvent.HasProperties))
             {
-                batch.AddLogRecord(ScopeName, logEvent, RenderLogEvent(Layout, logEvent), logEvent.Properties);
+                batch.AddLogRecord(logEvent, logMessage, logEvent.Properties);
             }
             else
             {
-                batch.AddLogRecord(ScopeName, logEvent, RenderLogEvent(Layout, logEvent), properties);
+                batch.AddLogRecord(logEvent, logMessage, properties);
             }
         }
 
@@ -264,6 +269,82 @@ namespace NLog.Targets
                     continue;
                 yield return new KeyValuePair<string, object?>(prop.Name, value);
             }
+        }
+
+        IEnumerable<KeyValuePair<string, string>> GetResourceAttributes(LogEventInfo firstEvent)
+        {
+            Layout? serviceNameLayout = ServiceName;
+            Layout? serviceVersionLayout = ServiceVersion;
+            Layout? hostNameLayout = HostName;
+            Layout? operatingSystemLayout = _defaultOperatingSystem;
+            Layout? processIdLayout = _defaultProcessId;
+
+            for (int j = 0; j < ResourceAttributes.Count; ++j)
+            {
+                var attr = ResourceAttributes[j];
+                if (string.IsNullOrWhiteSpace(attr.Name))
+                    continue;
+
+                var value = RenderLogEvent(attr.Layout, firstEvent);
+                if (!attr.IncludeEmptyValue && string.IsNullOrWhiteSpace(value))
+                    continue;
+
+                if (attr.Name == "service.name")
+                    serviceNameLayout = null;
+                else if (attr.Name == "service.version")
+                    serviceVersionLayout = null;
+                else if (attr.Name == "host.name")
+                    hostNameLayout = null;
+                else if (attr.Name == "os.type")
+                    operatingSystemLayout = null;
+                else if (attr.Name == "process.id")
+                    processIdLayout = null;
+                yield return new KeyValuePair<string, string>(attr.Name, value);
+            }
+
+            if (serviceNameLayout != null)
+            {
+                var serviceName = RenderLogEvent(serviceNameLayout, firstEvent);
+                if (string.IsNullOrEmpty(serviceName))
+                    serviceName = "Unknown";
+                yield return new KeyValuePair<string, string>("service.name", serviceName);
+            }
+            if (serviceVersionLayout != null)
+            {
+                var serviceVersion = RenderLogEvent(serviceVersionLayout, firstEvent);
+                if (!string.IsNullOrEmpty(serviceVersion))
+                    yield return new KeyValuePair<string, string>("service.version", serviceVersion);
+            }
+            if (processIdLayout != null)
+            {
+                var processId = RenderLogEvent(processIdLayout, firstEvent);
+                if (!string.IsNullOrEmpty(processId))
+                    yield return new KeyValuePair<string, string>("process.id", processId);
+            }
+            if (hostNameLayout != null)
+            {
+                var hostName = RenderLogEvent(hostNameLayout, firstEvent);
+                if (!string.IsNullOrEmpty(hostName))
+                    yield return new KeyValuePair<string, string>("host.name", hostName);
+            }
+            if (operatingSystemLayout != null)
+            {
+                var operatingSystem = RenderLogEvent(operatingSystemLayout, firstEvent);
+                if (!string.IsNullOrEmpty(operatingSystem))
+                    yield return new KeyValuePair<string, string>("os.type", operatingSystem);
+            }
+        }
+
+        private static string ResolveOperatingSystem()
+        {
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+                return "windows";
+            else if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux))
+                return "linux";
+            else if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
+                return "osx";
+            else
+                return "unknown";
         }
 
         private async Task SendLastChunkAndAwaitPendingAsync(HttpContent lastContent, List<Task<HttpResponseMessage>>? pendingTasks, CancellationToken cancellationToken)
@@ -300,7 +381,7 @@ namespace NLog.Targets
 
             try
             {
-                var batch = CreateNewBatch(batchStream, logEvents[0]);
+                var batch = CreateNewBatch(batchStream);
 
                 for (int i = 0; i < logEvents.Count; i++)
                 {
@@ -317,8 +398,7 @@ namespace NLog.Targets
 
                         batchStream = RentMemoryStream();
                         chunks.Add(batchStream);
-                        var nextBatch = logEvents[i + 1];
-                        batch = CreateNewBatch(batchStream, nextBatch);
+                        batch = CreateNewBatch(batchStream);
                     }
                 }
 

--- a/src/NLog.Targets.OpenTelemetryHttp/OpenTelemetryHttpTarget.cs
+++ b/src/NLog.Targets.OpenTelemetryHttp/OpenTelemetryHttpTarget.cs
@@ -58,7 +58,6 @@ namespace NLog.Targets
     /// <c>OTEL_EXPORTER_OTLP_HEADERS</c>, <c>OTEL_EXPORTER_OTLP_LOGS_HEADERS</c>,
     /// <c>OTEL_EXPORTER_OTLP_COMPRESSION</c>, <c>OTEL_EXPORTER_OTLP_LOGS_COMPRESSION</c>,
     /// <c>OTEL_EXPORTER_OTLP_TIMEOUT</c>, <c>OTEL_EXPORTER_OTLP_LOGS_TIMEOUT</c>,
-    /// <c>OTEL_EXPORTER_OTLP_PROTOCOL</c>, <c>OTEL_EXPORTER_OTLP_LOGS_PROTOCOL</c>,
     /// <c>OTEL_SERVICE_NAME</c>, <c>OTEL_RESOURCE_ATTRIBUTES</c>.
     /// Environment variables are resolved using NLog <c>${environment}</c> layout renderer.
     /// </para>
@@ -154,7 +153,7 @@ namespace NLog.Targets
             try
             {
                 if (Compress != HttpCompressionType.None)
-                    await WriteCompressedAsync(logEvents, chunks, cancellationToken).ConfigureAwait(false);
+                    await WriteGZipCompressedAsync(logEvents, chunks, cancellationToken).ConfigureAwait(false);
                 else
                     await WriteRawAsync(logEvents, chunks, cancellationToken).ConfigureAwait(false);
             }
@@ -173,123 +172,69 @@ namespace NLog.Targets
             var output = RentMemoryStream();
             chunks.Add(output);
 
+            var batch = CreateNewBatch(output, logEvents[0]);
+
             for (int i = 0; i < logEvents.Count; i++)
             {
-                SerializeLogEvent(logEvents[i], output);
+                var logEvent = logEvents[i];
+
+                WriteLogRecord(ref batch, logEvent);
 
                 if (output.Length >= MaxPayloadSizeBytes && i < logEvents.Count - 1)
                 {
+                    batch.Dispose();    //  Complete batch, and flush to output stream
                     var sendTask = HttpClientSendAsync(_logsUrl, BuildHttpContent(output), cancellationToken);
+
                     pendingTasks ??= new List<Task<HttpResponseMessage>>();
                     pendingTasks.Add(sendTask);
+
                     output = RentMemoryStream();
                     chunks.Add(output);
+                    var nextEvent = logEvents[i + 1];
+                    batch = CreateNewBatch(output, nextEvent);
                 }
             }
 
+            batch.Dispose();    //  Complete batch, and flush to output stream
             await SendLastChunkAndAwaitPendingAsync(BuildHttpContent(output), pendingTasks, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task SendLastChunkAndAwaitPendingAsync(HttpContent lastContent, List<Task<HttpResponseMessage>>? pendingTasks, CancellationToken cancellationToken)
+        private OtlpBatchBuilder CreateNewBatch(MemoryStream stream, LogEventInfo firstEvent)
         {
-            using var lastResponse = await HttpClientSendAsync(_logsUrl, lastContent, cancellationToken).ConfigureAwait(false);
-            if (pendingTasks != null)
-            {
-                if (pendingTasks.Count == 1)
-                {
-                    using var response = await pendingTasks[0].ConfigureAwait(false);
-                }
-                else
-                {
-                    var responses = await Task.WhenAll(pendingTasks).ConfigureAwait(false);
-                    foreach (var response in responses)
-                        response?.Dispose();
-                }
-            }
-        }
+            var batch = _serializer.BeginBatch(stream);
 
-        private static ByteArrayContent BuildHttpContent(MemoryStream output)
-        {
-            return new ByteArrayContent(output.GetBuffer(), 0, (int)output.Length);
-        }
-
-        private async Task WriteCompressedAsync(IList<LogEventInfo> logEvents, List<MemoryStream> chunks, CancellationToken cancellationToken)
-        {
-            List<Task<HttpResponseMessage>>? pendingTasks = null;
-            var compressionLevel = Compress == HttpCompressionType.GZipFast ? CompressionLevel.Fastest : CompressionLevel.Optimal;
-            var eventBuffer = RentMemoryStream();
-            var compressedOutput = RentMemoryStream();
-            chunks.Add(compressedOutput);
-            GZipStream? gzipStream = new GZipStream(compressedOutput, compressionLevel, leaveOpen: true);
-            try
-            {
-                for (int i = 0; i < logEvents.Count; i++)
-                {
-                    eventBuffer.Position = 0;
-                    eventBuffer.SetLength(0);
-                    SerializeLogEvent(logEvents[i], eventBuffer);
-                    gzipStream.Write(eventBuffer.GetBuffer(), 0, (int)eventBuffer.Length);
-
-                    if (compressedOutput.Length >= MaxPayloadSizeBytes && i < logEvents.Count - 1)
-                    {
-                        gzipStream.Dispose();
-                        gzipStream = null;
-                        var sendTask = HttpClientSendAsync(_logsUrl, BuildGzipContent(compressedOutput), cancellationToken);
-                        pendingTasks ??= new List<Task<HttpResponseMessage>>();
-                        pendingTasks.Add(sendTask);
-                        compressedOutput = RentMemoryStream();
-                        chunks.Add(compressedOutput);
-                        gzipStream = new GZipStream(compressedOutput, compressionLevel, leaveOpen: true);
-                    }
-                }
-
-                gzipStream.Dispose();
-                gzipStream = null;
-            }
-            finally
-            {
-                gzipStream?.Dispose();
-                ReturnMemoryStream(eventBuffer);
-            }
-
-            await SendLastChunkAndAwaitPendingAsync(BuildGzipContent(compressedOutput), pendingTasks, cancellationToken).ConfigureAwait(false);
-        }
-
-        private static HttpContent BuildGzipContent(MemoryStream compressedPayload)
-        {
-            var content = new ByteArrayContent(compressedPayload.GetBuffer(), 0, (int)compressedPayload.Length);
-            content.Headers.ContentEncoding.Add("gzip");
-            return content;
-        }
-
-        private void SerializeLogEvent(LogEventInfo logEvent, MemoryStream output)
-        {
-            using var builder = _serializer.BeginRecord(output);
-
-            var serviceName = RenderLogEvent(ServiceName, logEvent);
-            if (serviceName is null || string.IsNullOrWhiteSpace(serviceName))
+            var serviceName = RenderLogEvent(ServiceName, firstEvent);
+            if (string.IsNullOrWhiteSpace(serviceName))
                 serviceName = "Unknown";
-            builder.AddResourceAttribute("service.name", serviceName);
 
-            for (int j = 0; j < ResourceAttributes.Count; j++)
+            batch.AddResourceAttribute("service.name", serviceName);
+
+            for (int j = 0; j < ResourceAttributes.Count; ++j)
             {
                 var attr = ResourceAttributes[j];
-                if (attr.Name is null || string.IsNullOrWhiteSpace(attr.Name))
+                if (string.IsNullOrWhiteSpace(attr.Name))
                     continue;
-                var value = RenderLogEvent(attr.Layout, logEvent);
+
+                var value = RenderLogEvent(attr.Layout, firstEvent);
                 if (!attr.IncludeEmptyValue && string.IsNullOrWhiteSpace(value))
                     continue;
-                builder.AddResourceAttribute(attr.Name, value);
+
+                batch.AddResourceAttribute(attr.Name, value);
             }
 
+            return batch;
+        }
+
+        private void WriteLogRecord(ref OtlpBatchBuilder batch, LogEventInfo logEvent)
+        {
             var properties = GetLogEventProperties(logEvent);
             if (properties is null && (IncludeEventProperties && logEvent.HasProperties))
             {
-                builder.AddScopeLogs(ScopeName, logEvent, RenderLogEvent(Layout, logEvent), logEvent.Properties);
+                batch.AddLogRecord(ScopeName, logEvent, RenderLogEvent(Layout, logEvent), logEvent.Properties);
             }
             else
             {
-                builder.AddScopeLogs(ScopeName, logEvent, RenderLogEvent(Layout, logEvent), properties);
+                batch.AddLogRecord(ScopeName, logEvent, RenderLogEvent(Layout, logEvent), properties);
             }
         }
 
@@ -319,6 +264,97 @@ namespace NLog.Targets
                     continue;
                 yield return new KeyValuePair<string, object?>(prop.Name, value);
             }
+        }
+
+        private async Task SendLastChunkAndAwaitPendingAsync(HttpContent lastContent, List<Task<HttpResponseMessage>>? pendingTasks, CancellationToken cancellationToken)
+        {
+            using var lastResponse = await HttpClientSendAsync(_logsUrl, lastContent, cancellationToken).ConfigureAwait(false);
+            if (pendingTasks != null)
+            {
+                if (pendingTasks.Count == 1)
+                {
+                    using var response = await pendingTasks[0].ConfigureAwait(false);
+                }
+                else
+                {
+                    var responses = await Task.WhenAll(pendingTasks).ConfigureAwait(false);
+                    foreach (var response in responses)
+                        response?.Dispose();
+                }
+            }
+        }
+
+        private static ByteArrayContent BuildHttpContent(MemoryStream output)
+        {
+            return new ByteArrayContent(output.GetBuffer(), 0, (int)output.Length);
+        }
+
+        private async Task WriteGZipCompressedAsync(
+            IList<LogEventInfo> logEvents,
+            List<MemoryStream> chunks,
+            CancellationToken cancellationToken)
+        {
+            List<Task<HttpResponseMessage>>? pendingTasks = null;
+            var batchStream = RentMemoryStream();
+            chunks.Add(batchStream);
+
+            try
+            {
+                var batch = CreateNewBatch(batchStream, logEvents[0]);
+
+                for (int i = 0; i < logEvents.Count; i++)
+                {
+                    WriteLogRecord(ref batch, logEvents[i]);
+
+                    if (batchStream.Length >= MaxPayloadSizeBytes && i < logEvents.Count - 1)
+                    {
+                        batch.Dispose();
+
+                        var compressedStream = WriteGZipCompressed(batchStream);
+                        chunks.Add(compressedStream);
+                        pendingTasks ??= new List<Task<HttpResponseMessage>>();
+                        pendingTasks.Add(HttpClientSendAsync(_logsUrl, BuildGzipContent(compressedStream), cancellationToken));
+
+                        batchStream = RentMemoryStream();
+                        chunks.Add(batchStream);
+                        var nextBatch = logEvents[i + 1];
+                        batch = CreateNewBatch(batchStream, nextBatch);
+                    }
+                }
+
+                batch.Dispose();
+
+                var finalCompressed = WriteGZipCompressed(batchStream);
+                chunks.Add(finalCompressed);
+
+                await SendLastChunkAndAwaitPendingAsync(
+                    BuildGzipContent(finalCompressed),
+                    pendingTasks,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                ReturnMemoryStream(batchStream);
+            }
+        }
+
+        private MemoryStream WriteGZipCompressed(MemoryStream uncompressed)
+        {
+            var compressedOutput = RentMemoryStream();
+            var compressionLevel = Compress == HttpCompressionType.GZipFast ? CompressionLevel.Fastest : CompressionLevel.Optimal;
+            using (var gzip = new GZipStream(compressedOutput, compressionLevel, leaveOpen: true))
+            {
+                gzip.Write(uncompressed.GetBuffer(), 0, (int)uncompressed.Length);
+            }
+            compressedOutput.Position = 0;
+            return compressedOutput;
+        }
+
+        private static HttpContent BuildGzipContent(MemoryStream compressedPayload)
+        {
+            var content = new ByteArrayContent(compressedPayload.GetBuffer(), 0, (int)compressedPayload.Length);
+            content.Headers.ContentEncoding.Add("gzip");
+            return content;
         }
 
         private MemoryStream RentMemoryStream()
@@ -404,7 +440,7 @@ namespace NLog.Targets
                 if (string.IsNullOrWhiteSpace(timeoutStr))
                     timeoutStr = GetEnvironmentValueFromLayout("OTEL_EXPORTER_OTLP_TIMEOUT");
                 if (!string.IsNullOrWhiteSpace(timeoutStr) && int.TryParse(timeoutStr!.Trim(), out var timeoutMs) && timeoutMs > 0)
-                    SendTimeoutSeconds = Math.Max(1, timeoutMs / 1000);
+                    SendTimeoutSeconds = (int)Math.Ceiling(timeoutMs / 1000.0);
             }
 
             // Resource Attributes: OTEL_RESOURCE_ATTRIBUTES (format: key1=value1,key2=value2)

--- a/src/NLog.Targets.OpenTelemetryHttp/README.md
+++ b/src/NLog.Targets.OpenTelemetryHttp/README.md
@@ -61,6 +61,8 @@ Supports standard OpenTelemetry environment variables as fallback defaults:
 | ------------------------ | -------------------------------| -----------------------------------------------------------------------------|
 | `url`                    | OTEL_EXPORTER_OTLP_ENDPOINT    | OTLP/HTTP endpoint URL. Automatically append `/v1/logs` when missing         |
 | `serviceName`            | `${appdomain:format=Friendly}` | OpenTelemetry `service.name` resource attribute.                             |
+| `serviceVersion`         | `${assembly-version:Default=}` | OpenTelemetry `service.version` resource attribute.                          |
+| `hostName`               | `${hostname}`                  | OpenTelemetry `host.name` resource attribute.                                |
 | `scopeName`              | `NLog`                         | OpenTelemetry instrumentation scope name.                                    |
 | `layout`                 | `${message}`                   | Layout used for the OTLP log body (message text).                            |
 | `traceId`                | `${activity:property=TraceId}` | Layout used to populate the OTLP LogRecord TraceId field.                    |

--- a/tests/NLog.Targets.OpenTelemetryHttp.Tests/OpenTelemetryHttpTests.cs
+++ b/tests/NLog.Targets.OpenTelemetryHttp.Tests/OpenTelemetryHttpTests.cs
@@ -38,6 +38,7 @@ namespace NLog.Targets.HttpOTLP.Tests
     using System.Diagnostics;
     using System.IO;
     using System.IO.Compression;
+    using System.Linq;
     using System.Net;
     using System.Net.Sockets;
     using System.Text;
@@ -234,15 +235,7 @@ namespace NLog.Targets.HttpOTLP.Tests
                 var attributes = logRecord.FindAll(f => f.FieldNumber == 6);
 
                 // Parse each KeyValue to extract key name and AnyValue wire type
-                var typedAttributes = new Dictionary<string, ProtobufField>();
-                for (int i = 0; i < attributes.Count; i++)
-                {
-                    var kvFields = ReadProtobufFields(attributes[i].Data);
-                    var keyField = kvFields.Find(f => f.FieldNumber == 1);
-                    var valueField = kvFields.Find(f => f.FieldNumber == 2);
-                    var keyName = Encoding.UTF8.GetString(keyField.Data);
-                    typedAttributes[keyName] = valueField;
-                }
+                var typedAttributes = ParseKeyValueList(attributes);
 
                 // BoolProp: AnyValue field 2 (bool_value), varint wire type 0
                 var boolAnyValue = ReadProtobufFields(typedAttributes["BoolProp"].Data);
@@ -271,6 +264,22 @@ namespace NLog.Targets.HttpOTLP.Tests
                 Assert.Equal(2, enumAnyValue[0].WireType);    // length-delimited
                 Assert.Equal("Resume", Encoding.UTF8.GetString(enumAnyValue[0].Data));
             }
+        }
+
+        private static Dictionary<string, ProtobufField> ParseKeyValueList(List<ProtobufField> attributes)
+        {
+            var result = new Dictionary<string, ProtobufField>();
+
+            foreach (var attr in attributes)
+            {
+                var kvFields = ReadProtobufFields(attr.Data);
+                var keyField = kvFields.Find(f => f.FieldNumber == 1);
+                var valueField = kvFields.Find(f => f.FieldNumber == 2);
+                var keyName = Encoding.UTF8.GetString(keyField.Data);
+                result.Add(keyName, valueField);
+            }
+
+            return result;
         }
 
         [Fact]
@@ -308,15 +317,7 @@ namespace NLog.Targets.HttpOTLP.Tests
 
                 // Collect all attribute fields
                 var attributes = logRecord.FindAll(f => f.FieldNumber == 6);
-                var typedAttributes = new Dictionary<string, ProtobufField>();
-                for (int i = 0; i < attributes.Count; i++)
-                {
-                    var kvFields = ReadProtobufFields(attributes[i].Data);
-                    var keyField = kvFields.Find(f => f.FieldNumber == 1);
-                    var valueField = kvFields.Find(f => f.FieldNumber == 2);
-                    var keyName = Encoding.UTF8.GetString(keyField.Data);
-                    typedAttributes[keyName] = valueField;
-                }
+                var typedAttributes = ParseKeyValueList(attributes);
 
                 // All special doubles should be encoded as double_value (field 4, fixed64 wire type 1)
                 var nanAnyValue = ReadProtobufFields(typedAttributes["NaNProp"].Data);
@@ -402,13 +403,7 @@ namespace NLog.Targets.HttpOTLP.Tests
                 Assert.Equal(2, kvListEntries.Count);
 
                 // Parse nested entries
-                var nestedEntries = new Dictionary<string, ProtobufField>();
-                for (int i = 0; i < kvListEntries.Count; i++)
-                {
-                    var entryFields = ReadProtobufFields(kvListEntries[i].Data);
-                    var entryKey = Encoding.UTF8.GetString(entryFields.Find(f => f.FieldNumber == 1).Data);
-                    nestedEntries[entryKey] = entryFields.Find(f => f.FieldNumber == 2);
-                }
+                var nestedEntries = ParseKeyValueList(kvListEntries);
 
                 // nestedKey should be string_value (AnyValue field 1)
                 var nestedKeyAnyValue = ReadProtobufFields(nestedEntries["nestedKey"].Data);
@@ -777,6 +772,70 @@ namespace NLog.Targets.HttpOTLP.Tests
                 // No trace_id (field 9) or span_id (field 10) should be present
                 Assert.DoesNotContain(logRecord, f => f.FieldNumber == 9);
                 Assert.DoesNotContain(logRecord, f => f.FieldNumber == 10);
+            }
+        }
+
+        [Fact]
+        public void MultipleLogEvents_ShareSameServiceName()
+        {
+            using (var server = new SimpleHttpServer())
+            {
+                var target = new OpenTelemetryHttpTarget
+                {
+                    Url = $"http://127.0.0.1:{server.Port}/v1/logs",
+                    Layout = "${message}",
+                    ServiceName = "TestService"
+                };
+
+                using (var logFactory = BuildLogFactory(target))
+                {
+                    var logger = logFactory.GetLogger("TestLogger");
+
+                    logger.Info("event-1");
+                    logger.Info("event-2");
+                    logger.Info("event-3");
+
+                    logFactory.Flush();
+                }
+
+                var requests = server.WaitForRequests(1);
+                Assert.Single(requests);
+
+                // Decode ExportLogsServiceRequest
+                var topFields = ReadProtobufFields(requests[0].BodyBytes);
+
+                // ResourceLogs (field 1)
+                var resourceLogs = ReadProtobufFields(
+                    topFields.Find(f => f.FieldNumber == 1).Data);
+
+                // Resource (field 1 inside ResourceLogs)
+                var resourceFields = ReadProtobufFields(
+                    resourceLogs.Find(f => f.FieldNumber == 1).Data);
+
+                // Parse KeyValue list into dictionary
+                var attributes = ParseKeyValueList(resourceFields);
+
+                // Get value container
+                var valueField = attributes["service.name"];
+
+                // Decode inner StringValue message
+                var valueFields = ReadProtobufFields(valueField.Data);
+
+                // StringValue is field 1
+                var stringValueField = valueFields.Find(f => f.FieldNumber == 1);
+
+                var serviceName = Encoding.UTF8.GetString(stringValueField.Data);
+                Assert.Equal("TestService", serviceName);
+
+                // Verify multiple log records exist in batch
+                var scopeLogs = ReadProtobufFields(
+                    resourceLogs.Find(f => f.FieldNumber == 2).Data);
+
+                var logRecords = scopeLogs
+                    .Where(f => f.FieldNumber == 2)
+                    .ToList();
+
+                Assert.True(logRecords.Count >= 3);
             }
         }
 

--- a/tests/NLog.Targets.OpenTelemetryHttp.Tests/OpenTelemetryHttpTests.cs
+++ b/tests/NLog.Targets.OpenTelemetryHttp.Tests/OpenTelemetryHttpTests.cs
@@ -31,7 +31,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-namespace NLog.Targets.HttpOTLP.Tests
+namespace NLog.Targets.OpenTelemetryHttp.Tests
 {
     using System;
     using System.Collections.Generic;
@@ -105,11 +105,16 @@ namespace NLog.Targets.HttpOTLP.Tests
                 var requests = server.WaitForRequests(1);
                 Assert.Single(requests);
 
-                // Protobuf stores strings as raw UTF-8, so the message should appear in the byte stream
-                var bodyText = Encoding.UTF8.GetString(requests[0].BodyBytes);
-                Assert.Contains("hello otlp world", bodyText);
-                Assert.Contains("TestService", bodyText);
-                Assert.Contains("TestLogger", bodyText);
+                var logRecord = ProtobufParser.GetLogRecord(requests[0].BodyBytes);
+                var logFields = logRecord.AsMessage();
+                var bodyValue = logFields.GetField(5).AsAnyValueString();
+                Assert.Equal("hello otlp world", bodyValue);
+
+                var logAttributes = logFields.GetFieldValues(6);
+                Assert.Equal("TestLogger", logAttributes["logger.name"].AsAnyValueString());
+
+                var resourceAttributes = ProtobufParser.GetResourceAttributes(requests[0].BodyBytes);
+                Assert.Equal("TestService", resourceAttributes["service.name"].AsAnyValueString());
             }
         }
 
@@ -134,9 +139,13 @@ namespace NLog.Targets.HttpOTLP.Tests
                 var requests = server.WaitForRequests(1);
                 Assert.Single(requests);
 
-                var bodyText = Encoding.UTF8.GetString(requests[0].BodyBytes);
-                Assert.Contains("Warn", bodyText);
-                Assert.Contains("warning message", bodyText);
+                var logRecord = ProtobufParser.GetLogRecord(requests[0].BodyBytes);
+                var logFields = logRecord.AsMessage();
+                var bodyValue = logFields.GetField(5).AsAnyValueString();
+                Assert.Equal("warning message", bodyValue);
+
+                var severityField = logFields.GetField(3).AsString();
+                Assert.Equal("Warn", severityField);
             }
         }
 
@@ -162,8 +171,15 @@ namespace NLog.Targets.HttpOTLP.Tests
                 var requests = server.WaitForRequests(1);
                 Assert.Single(requests);
 
-                var bodyText = Encoding.UTF8.GetString(requests[0].BodyBytes);
-                Assert.Contains("MyInstrumentationScope", bodyText);
+
+                var scopeLogs = ProtobufParser.GetScopeLogs(requests[0].BodyBytes);
+
+                var scopeName = scopeLogs
+                    .GetField(1)   // InstrumentationScope
+                    .GetField(1)   // name
+                    .AsString();
+
+                Assert.Equal("MyInstrumentationScope", scopeName);
             }
         }
 
@@ -191,9 +207,8 @@ namespace NLog.Targets.HttpOTLP.Tests
                 var requests = server.WaitForRequests(1);
                 Assert.Single(requests);
 
-                var bodyText = Encoding.UTF8.GetString(requests[0].BodyBytes);
-                Assert.Contains("CustomKey", bodyText);
-                Assert.Contains("CustomValue", bodyText);
+                var attributes = ProtobufParser.GetLogRecord(requests[0].BodyBytes).AsMessage().GetFieldValues(6);
+                Assert.Equal("CustomValue", attributes["CustomKey"].AsAnyValueString());
             }
         }
 
@@ -212,12 +227,14 @@ namespace NLog.Targets.HttpOTLP.Tests
                 using (var logFactory = BuildLogFactory(target))
                 {
                     var logger = logFactory.GetLogger("TestLogger");
+
                     var logEvent = new LogEventInfo(LogLevel.Info, "TestLogger", "typed props");
                     logEvent.Properties["BoolProp"] = true;
                     logEvent.Properties["IntProp"] = 42;
                     logEvent.Properties["DoubleProp"] = 3.14;
                     logEvent.Properties["StringProp"] = "hello";
                     logEvent.Properties["EnumProp"] = TraceEventType.Resume;
+
                     logger.Log(logEvent);
                     logFactory.Flush();
                 }
@@ -225,61 +242,15 @@ namespace NLog.Targets.HttpOTLP.Tests
                 var requests = server.WaitForRequests(1);
                 Assert.Single(requests);
 
-                // Navigate to LogRecord attributes
-                var topFields = ReadProtobufFields(requests[0].BodyBytes);
-                var resourceLogs = ReadProtobufFields(topFields.Find(f => f.FieldNumber == 1).Data);
-                var scopeLogs = ReadProtobufFields(resourceLogs.Find(f => f.FieldNumber == 2).Data);
-                var logRecord = ReadProtobufFields(scopeLogs.Find(f => f.FieldNumber == 2).Data);
+                var logRecord = ProtobufParser.GetLogRecord(requests[0].BodyBytes);
+                var logAttributes = logRecord.AsMessage().GetFieldValues(6);
 
-                // Collect all attribute fields (field 6 = KeyValue in LogRecord)
-                var attributes = logRecord.FindAll(f => f.FieldNumber == 6);
-
-                // Parse each KeyValue to extract key name and AnyValue wire type
-                var typedAttributes = ParseKeyValueList(attributes);
-
-                // BoolProp: AnyValue field 2 (bool_value), varint wire type 0
-                var boolAnyValue = ReadProtobufFields(typedAttributes["BoolProp"].Data);
-                Assert.Equal(2, boolAnyValue[0].FieldNumber); // bool_value field
-                Assert.Equal(0, boolAnyValue[0].WireType);    // varint
-
-                // IntProp: AnyValue field 3 (int_value), varint wire type 0
-                var intAnyValue = ReadProtobufFields(typedAttributes["IntProp"].Data);
-                Assert.Equal(3, intAnyValue[0].FieldNumber);  // int_value field
-                Assert.Equal(0, intAnyValue[0].WireType);     // varint
-
-                // DoubleProp: AnyValue field 4 (double_value), fixed64 wire type 1
-                var doubleAnyValue = ReadProtobufFields(typedAttributes["DoubleProp"].Data);
-                Assert.Equal(4, doubleAnyValue[0].FieldNumber); // double_value field
-                Assert.Equal(1, doubleAnyValue[0].WireType);    // fixed64
-
-                // StringProp: AnyValue field 1 (string_value), length-delimited wire type 2
-                var stringAnyValue = ReadProtobufFields(typedAttributes["StringProp"].Data);
-                Assert.Equal(1, stringAnyValue[0].FieldNumber); // string_value field
-                Assert.Equal(2, stringAnyValue[0].WireType);    // length-delimited
-                Assert.Equal("hello", Encoding.UTF8.GetString(stringAnyValue[0].Data));
-
-                // EnumProp: AnyValue field 1 (string_value), length-delimited wire type 2
-                var enumAnyValue = ReadProtobufFields(typedAttributes["EnumProp"].Data);
-                Assert.Equal(1, enumAnyValue[0].FieldNumber); // string_value field
-                Assert.Equal(2, enumAnyValue[0].WireType);    // length-delimited
-                Assert.Equal("Resume", Encoding.UTF8.GetString(enumAnyValue[0].Data));
+                Assert.Equal(1, logAttributes["BoolProp"].AsAnyValue().AsInt64());
+                Assert.Equal(42, logAttributes["IntProp"].AsAnyValue().AsInt64());
+                Assert.Equal(3.14, logAttributes["DoubleProp"].AsAnyValue().AsDouble());
+                Assert.Equal("hello", logAttributes["StringProp"].AsAnyValue().AsString());
+                Assert.Equal("Resume", logAttributes["EnumProp"].AsAnyValue().AsString());
             }
-        }
-
-        private static Dictionary<string, ProtobufField> ParseKeyValueList(List<ProtobufField> attributes)
-        {
-            var result = new Dictionary<string, ProtobufField>();
-
-            foreach (var attr in attributes)
-            {
-                var kvFields = ReadProtobufFields(attr.Data);
-                var keyField = kvFields.Find(f => f.FieldNumber == 1);
-                var valueField = kvFields.Find(f => f.FieldNumber == 2);
-                var keyName = Encoding.UTF8.GetString(keyField.Data);
-                result.Add(keyName, valueField);
-            }
-
-            return result;
         }
 
         [Fact]
@@ -297,11 +268,13 @@ namespace NLog.Targets.HttpOTLP.Tests
                 using (var logFactory = BuildLogFactory(target))
                 {
                     var logger = logFactory.GetLogger("TestLogger");
+
                     var logEvent = new LogEventInfo(LogLevel.Info, "TestLogger", "special doubles");
                     logEvent.Properties["NaNProp"] = double.NaN;
                     logEvent.Properties["PosInfProp"] = double.PositiveInfinity;
                     logEvent.Properties["NegInfProp"] = double.NegativeInfinity;
                     logEvent.Properties["FloatNaNProp"] = float.NaN;
+
                     logger.Log(logEvent);
                     logFactory.Flush();
                 }
@@ -309,38 +282,20 @@ namespace NLog.Targets.HttpOTLP.Tests
                 var requests = server.WaitForRequests(1);
                 Assert.Single(requests);
 
-                // Navigate to LogRecord attributes
-                var topFields = ReadProtobufFields(requests[0].BodyBytes);
-                var resourceLogs = ReadProtobufFields(topFields.Find(f => f.FieldNumber == 1).Data);
-                var scopeLogs = ReadProtobufFields(resourceLogs.Find(f => f.FieldNumber == 2).Data);
-                var logRecord = ReadProtobufFields(scopeLogs.Find(f => f.FieldNumber == 2).Data);
+                var logRecord = ProtobufParser.GetLogRecord(requests[0].BodyBytes);
+                var attributes = logRecord.AsMessage().GetFieldValues(6);
 
-                // Collect all attribute fields
-                var attributes = logRecord.FindAll(f => f.FieldNumber == 6);
-                var typedAttributes = ParseKeyValueList(attributes);
+                var nan = attributes["NaNProp"].AsAnyValue().AsDouble();
+                Assert.True(double.IsNaN(nan));
 
-                // All special doubles should be encoded as double_value (field 4, fixed64 wire type 1)
-                var nanAnyValue = ReadProtobufFields(typedAttributes["NaNProp"].Data);
-                Assert.Equal(4, nanAnyValue[0].FieldNumber);
-                Assert.Equal(1, nanAnyValue[0].WireType);
-                Assert.Equal(8, nanAnyValue[0].Data.Length);
-                Assert.True(double.IsNaN(BitConverter.ToDouble(nanAnyValue[0].Data, 0)));
+                var posInf = attributes["PosInfProp"].AsAnyValue().AsDouble();
+                Assert.True(double.IsPositiveInfinity(posInf));
 
-                var posInfAnyValue = ReadProtobufFields(typedAttributes["PosInfProp"].Data);
-                Assert.Equal(4, posInfAnyValue[0].FieldNumber);
-                Assert.Equal(1, posInfAnyValue[0].WireType);
-                Assert.True(double.IsPositiveInfinity(BitConverter.ToDouble(posInfAnyValue[0].Data, 0)));
+                var negInf = attributes["NegInfProp"].AsAnyValue().AsDouble();
+                Assert.True(double.IsNegativeInfinity(negInf));
 
-                var negInfAnyValue = ReadProtobufFields(typedAttributes["NegInfProp"].Data);
-                Assert.Equal(4, negInfAnyValue[0].FieldNumber);
-                Assert.Equal(1, negInfAnyValue[0].WireType);
-                Assert.True(double.IsNegativeInfinity(BitConverter.ToDouble(negInfAnyValue[0].Data, 0)));
-
-                // float.NaN should also be encoded as double_value (TypeCode.Single → ToDouble)
-                var floatNanAnyValue = ReadProtobufFields(typedAttributes["FloatNaNProp"].Data);
-                Assert.Equal(4, floatNanAnyValue[0].FieldNumber);
-                Assert.Equal(1, floatNanAnyValue[0].WireType);
-                Assert.True(double.IsNaN(BitConverter.ToDouble(floatNanAnyValue[0].Data, 0)));
+                var floatNaN = attributes["FloatNaNProp"].AsAnyValue().AsDouble();
+                Assert.True(double.IsNaN(floatNaN));
             }
         }
 
@@ -359,12 +314,14 @@ namespace NLog.Targets.HttpOTLP.Tests
                 using (var logFactory = BuildLogFactory(target))
                 {
                     var logger = logFactory.GetLogger("TestLogger");
+
                     var logEvent = new LogEventInfo(LogLevel.Info, "TestLogger", "dict prop");
                     logEvent.Properties["MapProp"] = new Dictionary<string, object>
                     {
                         ["nestedKey"] = "nestedValue",
                         ["nestedInt"] = 42,
                     };
+
                     logger.Log(logEvent);
                     logFactory.Flush();
                 }
@@ -372,48 +329,18 @@ namespace NLog.Targets.HttpOTLP.Tests
                 var requests = server.WaitForRequests(1);
                 Assert.Single(requests);
 
-                // Navigate to LogRecord attributes
-                var topFields = ReadProtobufFields(requests[0].BodyBytes);
-                var resourceLogs = ReadProtobufFields(topFields.Find(f => f.FieldNumber == 1).Data);
-                var scopeLogs = ReadProtobufFields(resourceLogs.Find(f => f.FieldNumber == 2).Data);
-                var logRecord = ReadProtobufFields(scopeLogs.Find(f => f.FieldNumber == 2).Data);
+                var logRecord = ProtobufParser.GetLogRecord(requests[0].BodyBytes);
+                var attributes = logRecord.AsMessage().GetFieldValues(6);
 
-                // Find the MapProp attribute
-                var attributes = logRecord.FindAll(f => f.FieldNumber == 6);
-                ProtobufField mapAnyValue = default;
-                for (int i = 0; i < attributes.Count; i++)
-                {
-                    var kvFields = ReadProtobufFields(attributes[i].Data);
-                    var keyField = kvFields.Find(f => f.FieldNumber == 1);
-                    if (Encoding.UTF8.GetString(keyField.Data) == "MapProp")
-                    {
-                        mapAnyValue = kvFields.Find(f => f.FieldNumber == 2);
-                        break;
-                    }
-                }
-                Assert.True(mapAnyValue.Data.Length > 0, "MapProp attribute should be present");
+                var kvList = attributes["MapProp"].AsAnyValue().AsMessage();
 
-                // AnyValue field 6 = kvlist_value (wire type 2, length-delimited)
-                var anyValueFields = ReadProtobufFields(mapAnyValue.Data);
-                var kvListField = anyValueFields.Find(f => f.FieldNumber == 6);
-                Assert.Equal(2, kvListField.WireType);
+                var map = kvList.GetFieldValues(1);
 
-                // KeyValueList { repeated KeyValue values = 1 }
-                var kvListEntries = ReadProtobufFields(kvListField.Data);
-                Assert.Equal(2, kvListEntries.Count);
+                // nestedKey → string_value
+                Assert.Equal("nestedValue", map["nestedKey"].AsAnyValue().AsString());
 
-                // Parse nested entries
-                var nestedEntries = ParseKeyValueList(kvListEntries);
-
-                // nestedKey should be string_value (AnyValue field 1)
-                var nestedKeyAnyValue = ReadProtobufFields(nestedEntries["nestedKey"].Data);
-                Assert.Equal(1, nestedKeyAnyValue[0].FieldNumber);
-                Assert.Equal("nestedValue", Encoding.UTF8.GetString(nestedKeyAnyValue[0].Data));
-
-                // nestedInt should be int_value (AnyValue field 3)
-                var nestedIntAnyValue = ReadProtobufFields(nestedEntries["nestedInt"].Data);
-                Assert.Equal(3, nestedIntAnyValue[0].FieldNumber);
-                Assert.Equal(0, nestedIntAnyValue[0].WireType);
+                // nestedInt → int_value
+                Assert.Equal(42, map["nestedInt"].AsAnyValue().AsInt64());
             }
         }
 
@@ -441,50 +368,18 @@ namespace NLog.Targets.HttpOTLP.Tests
                 var requests = server.WaitForRequests(1);
                 Assert.Single(requests);
 
-                // Navigate to LogRecord attributes
-                var topFields = ReadProtobufFields(requests[0].BodyBytes);
-                var resourceLogs = ReadProtobufFields(topFields.Find(f => f.FieldNumber == 1).Data);
-                var scopeLogs = ReadProtobufFields(resourceLogs.Find(f => f.FieldNumber == 2).Data);
-                var logRecord = ReadProtobufFields(scopeLogs.Find(f => f.FieldNumber == 2).Data);
+                var logRecord = ProtobufParser.GetLogRecord(requests[0].BodyBytes);
+                var attributes = logRecord.AsMessage().GetFieldValues(6);
 
-                // Find the ListProp attribute
-                var attributes = logRecord.FindAll(f => f.FieldNumber == 6);
-                ProtobufField listAnyValue = default;
-                for (int i = 0; i < attributes.Count; i++)
-                {
-                    var kvFields = ReadProtobufFields(attributes[i].Data);
-                    var keyField = kvFields.Find(f => f.FieldNumber == 1);
-                    if (Encoding.UTF8.GetString(keyField.Data) == "ListProp")
-                    {
-                        listAnyValue = kvFields.Find(f => f.FieldNumber == 2);
-                        break;
-                    }
-                }
-                Assert.True(listAnyValue.Data.Length > 0, "ListProp attribute should be present");
+                // AnyValue.array_value = field 5
+                var listAnyValue = attributes["ListProp"].AsAnyValue();
+                Assert.Equal(5, listAnyValue.FieldNumber);
+                var arrayEntries = listAnyValue.AsMessage();
 
-                // AnyValue field 5 = array_value (wire type 2, length-delimited)
-                var anyValueFields = ReadProtobufFields(listAnyValue.Data);
-                var arrayField = anyValueFields.Find(f => f.FieldNumber == 5);
-                Assert.Equal(2, arrayField.WireType);
-
-                // ArrayValue { repeated AnyValue values = 1 }
-                var arrayEntries = ReadProtobufFields(arrayField.Data);
                 Assert.Equal(3, arrayEntries.Count);
-
-                // Element 0: "alpha" → string_value (AnyValue field 1)
-                var elem0 = ReadProtobufFields(arrayEntries[0].Data);
-                Assert.Equal(1, elem0[0].FieldNumber);
-                Assert.Equal("alpha", Encoding.UTF8.GetString(elem0[0].Data));
-
-                // Element 1: 99 → int_value (AnyValue field 3)
-                var elem1 = ReadProtobufFields(arrayEntries[1].Data);
-                Assert.Equal(3, elem1[0].FieldNumber);
-                Assert.Equal(0, elem1[0].WireType);
-
-                // Element 2: true → bool_value (AnyValue field 2)
-                var elem2 = ReadProtobufFields(arrayEntries[2].Data);
-                Assert.Equal(2, elem2[0].FieldNumber);
-                Assert.Equal(0, elem2[0].WireType);
+                Assert.Equal("alpha", arrayEntries[0].AsMessage().GetField(1).AsString());
+                Assert.Equal(99, arrayEntries[1].AsMessage().GetField(3).AsInt64());
+                Assert.Equal(1, arrayEntries[2].AsMessage().GetField(2).AsInt64());
             }
         }
 
@@ -512,9 +407,9 @@ namespace NLog.Targets.HttpOTLP.Tests
                 var requests = server.WaitForRequests(1);
                 Assert.Single(requests);
 
-                var bodyText = Encoding.UTF8.GetString(requests[0].BodyBytes);
-                Assert.DoesNotContain("SecretKey", bodyText);
-                Assert.DoesNotContain("SecretValue", bodyText);
+                var logRecord = ProtobufParser.GetLogRecord(requests[0].BodyBytes);
+                var attributes = logRecord.AsMessage().GetFieldValues(6);
+                Assert.False(attributes.ContainsKey("SecretKey"));
             }
         }
 
@@ -539,11 +434,10 @@ namespace NLog.Targets.HttpOTLP.Tests
                 var requests = server.WaitForRequests(1);
                 Assert.Single(requests);
 
-                var bodyText = Encoding.UTF8.GetString(requests[0].BodyBytes);
-                Assert.Contains("exception.type", bodyText);
-                Assert.Contains("InvalidOperationException", bodyText);
-                Assert.Contains("exception.message", bodyText);
-                Assert.Contains("test exception", bodyText);
+                var logRecord = ProtobufParser.GetLogRecord(requests[0].BodyBytes);
+                var attributes = logRecord.AsMessage().GetFieldValues(6);
+                Assert.Equal(typeof(InvalidOperationException).ToString(), attributes["exception.type"].AsAnyValueString());
+                Assert.Equal("test exception", attributes["exception.message"].AsAnyValueString());
             }
         }
 
@@ -570,10 +464,12 @@ namespace NLog.Targets.HttpOTLP.Tests
                 var requests = server.WaitForRequests(1);
                 Assert.Single(requests);
 
-                var bodyText = Encoding.UTF8.GetString(requests[0].BodyBytes);
-                Assert.Contains("MySvc", bodyText);
-                Assert.Contains("deployment.environment", bodyText);
-                Assert.Contains("staging", bodyText);
+                var logRecord = ProtobufParser.GetLogRecord(requests[0].BodyBytes).AsMessage();
+                Assert.NotEmpty(logRecord);
+
+                var attributes = ProtobufParser.GetResourceAttributes(requests[0].BodyBytes);
+                Assert.Equal("MySvc", attributes["service.name"].AsAnyValueString());
+                Assert.Equal("staging", attributes["deployment.environment"].AsAnyValueString());
             }
         }
 
@@ -602,15 +498,31 @@ namespace NLog.Targets.HttpOTLP.Tests
                 var requests = server.WaitForRequests(1);
                 Assert.True(requests.Count >= 1);
 
-                // All messages should be in the protobuf payload(s)
-                var allBodyText = new StringBuilder();
+                var allLogRecords = new List<ProtobufParser.ProtobufField>();
                 foreach (var req in requests)
-                    allBodyText.Append(Encoding.UTF8.GetString(req.BodyBytes));
+                {
+                    var records = ProtobufParser.GetLogRecords(req.BodyBytes);
+                    allLogRecords.AddRange(records);
+                }
 
-                var combined = allBodyText.ToString();
-                Assert.Contains("batch1", combined);
-                Assert.Contains("batch2", combined);
-                Assert.Contains("batch3", combined);
+                // Ensure batching preserved all events
+                Assert.True(allLogRecords.Count >= 3);
+
+                // Validate payload content
+                var messages = allLogRecords
+                    .Select(r =>
+                    {
+                        var fields = r.AsMessage();
+
+                        // body = field 5 → AnyValue → string_value (field 1)
+                        var body = fields.GetField(5).AsMessage().GetField(1);
+                        return body.AsString();
+                    })
+                    .ToList();
+
+                Assert.Contains("batch1", messages);
+                Assert.Contains("batch2", messages);
+                Assert.Contains("batch3", messages);
             }
         }
 
@@ -638,8 +550,10 @@ namespace NLog.Targets.HttpOTLP.Tests
                 Assert.True(requests[0].Headers.TryGetValue("Content-Encoding", out var encoding));
                 Assert.Equal("gzip", encoding);
 
-                var decompressed = DecompressGzip(requests[0].BodyBytes);
-                Assert.Contains("compressed otlp message", decompressed);
+                var decompressedBytes = DecompressGzip(requests[0].BodyBytes);
+                var logRecord = ProtobufParser.GetLogRecord(decompressedBytes);
+                var body = logRecord.AsMessage().GetField(5).GetField(1).AsString();
+                Assert.Equal("compressed otlp message", body);
             }
         }
 
@@ -665,49 +579,34 @@ namespace NLog.Targets.HttpOTLP.Tests
                 var requests = server.WaitForRequests(1);
                 Assert.Single(requests);
 
-                // Parse the top-level ExportLogsServiceRequest
-                var topFields = ReadProtobufFields(requests[0].BodyBytes);
-                Assert.True(topFields.Count >= 1, "ExportLogsServiceRequest should have at least 1 field (resource_logs)");
+                var logRecord = ProtobufParser.GetLogRecord(requests[0].BodyBytes);
 
-                // Field 1 = ResourceLogs (wire type 2 = length-delimited)
-                var resourceLogsField = topFields.Find(f => f.FieldNumber == 1);
-                Assert.Equal(2, resourceLogsField.WireType);
+                // timestamp (field 1, fixed64)
+                var timestamp = logRecord.AsMessage().GetField(1);
+                Assert.Equal(1, timestamp.WireType);
+                Assert.Equal(8, timestamp.Data.Length);
 
-                // Parse ResourceLogs
-                var rlFields = ReadProtobufFields(resourceLogsField.Data);
-                Assert.True(rlFields.Count >= 2, "ResourceLogs should have resource and scope_logs");
-
-                // Field 1 = Resource, Field 2 = ScopeLogs
-                var resourceField = rlFields.Find(f => f.FieldNumber == 1);
-                Assert.Equal(2, resourceField.WireType);
-                var scopeLogsField = rlFields.Find(f => f.FieldNumber == 2);
-                Assert.Equal(2, scopeLogsField.WireType);
-
-                // Parse ScopeLogs and verify it has log_records (field 2)
-                var slFields = ReadProtobufFields(scopeLogsField.Data);
-                var logRecordField = slFields.Find(f => f.FieldNumber == 2);
-                Assert.NotNull(logRecordField.Data);
-                Assert.True(logRecordField.Data.Length > 0, "LogRecord should have content");
-
-                // Parse LogRecord and verify timestamp (field 1, fixed64) exists
-                var lrFields = ReadProtobufFields(logRecordField.Data);
-                var timestampField = lrFields.Find(f => f.FieldNumber == 1);
-                Assert.Equal(1, timestampField.WireType); // fixed64
-                Assert.Equal(8, timestampField.Data.Length);
+                // body (field 5 → AnyValue → string_value field 1)
+                var body = logRecord.AsMessage().GetField(5);
+                var bodyValue = body.AsMessage().GetField(1);
+                Assert.Equal("structure test", bodyValue.AsString());
             }
         }
 
         [Fact]
         public void TraceIdAndSpanId_EncodedAsBytesInLogRecord()
         {
+            const string expectedTraceId = "0af7651916cd43dd8448eb211c80319c";
+            const string expectedSpanId = "b7ad6b7169203331";
+
             using (var server = new SimpleHttpServer())
             {
                 var target = new OpenTelemetryHttpTarget
                 {
                     Url = $"http://127.0.0.1:{server.Port}/v1/logs",
                     Layout = "${message}",
-                    TraceId = NLog.Layouts.Layout<System.Diagnostics.ActivityTraceId?>.FromMethod(l => System.Diagnostics.ActivityTraceId.CreateFromString("0af7651916cd43dd8448eb211c80319c".AsSpan())),
-                    SpanId = NLog.Layouts.Layout<System.Diagnostics.ActivitySpanId?>.FromMethod(l => System.Diagnostics.ActivitySpanId.CreateFromString("b7ad6b7169203331".AsSpan())),
+                    TraceId = NLog.Layouts.Layout<System.Diagnostics.ActivityTraceId?>.FromMethod(l => System.Diagnostics.ActivityTraceId.CreateFromString(expectedTraceId.AsSpan())),
+                    SpanId = NLog.Layouts.Layout<System.Diagnostics.ActivitySpanId?>.FromMethod(l => System.Diagnostics.ActivitySpanId.CreateFromString(expectedSpanId.AsSpan())),
                 };
 
                 using (var logFactory = BuildLogFactory(target))
@@ -720,24 +619,26 @@ namespace NLog.Targets.HttpOTLP.Tests
                 var requests = server.WaitForRequests(1);
                 Assert.Single(requests);
 
-                // Navigate to LogRecord
-                var topFields = ReadProtobufFields(requests[0].BodyBytes);
-                var resourceLogs = ReadProtobufFields(topFields.Find(f => f.FieldNumber == 1).Data);
-                var scopeLogs = ReadProtobufFields(resourceLogs.Find(f => f.FieldNumber == 2).Data);
-                var logRecord = ReadProtobufFields(scopeLogs.Find(f => f.FieldNumber == 2).Data);
+                var logRecord = ProtobufParser.GetLogRecord(requests[0].BodyBytes);
+                var fields = logRecord.AsMessage();
 
-                // trace_id = field 9, bytes (wire type 2), 16 bytes
-                var traceIdField = logRecord.Find(f => f.FieldNumber == 9);
-                Assert.Equal(2, traceIdField.WireType);
-                Assert.Equal(16, traceIdField.Data.Length);
-                Assert.Equal("0af7651916cd43dd8448eb211c80319c", BitConverter.ToString(traceIdField.Data).Replace("-", "").ToLowerInvariant());
+                // trace_id = field 9 (bytes, 16 bytes)
+                var traceId = fields.GetField(9);
+                Assert.Equal(2, traceId.WireType);
+                Assert.Equal(16, traceId.Data.Length);
+                Assert.Equal(expectedTraceId, ToHex(traceId.Data));
 
-                // span_id = field 10, bytes (wire type 2), 8 bytes
-                var spanIdField = logRecord.Find(f => f.FieldNumber == 10);
-                Assert.Equal(2, spanIdField.WireType);
-                Assert.Equal(8, spanIdField.Data.Length);
-                Assert.Equal("b7ad6b7169203331", BitConverter.ToString(spanIdField.Data).Replace("-", "").ToLowerInvariant());
+                // span_id = field 10 (bytes, 8 bytes)
+                var spanId = fields.GetField(10);
+                Assert.Equal(2, spanId.WireType);
+                Assert.Equal(8, spanId.Data.Length);
+                Assert.Equal(expectedSpanId, ToHex(spanId.Data));
             }
+        }
+
+        private static string ToHex(byte[] bytes)
+        {
+            return BitConverter.ToString(bytes).Replace("-", "").ToLowerInvariant();
         }
 
         [Fact]
@@ -763,15 +664,13 @@ namespace NLog.Targets.HttpOTLP.Tests
                 var requests = server.WaitForRequests(1);
                 Assert.Single(requests);
 
-                // Navigate to LogRecord
-                var topFields = ReadProtobufFields(requests[0].BodyBytes);
-                var resourceLogs = ReadProtobufFields(topFields.Find(f => f.FieldNumber == 1).Data);
-                var scopeLogs = ReadProtobufFields(resourceLogs.Find(f => f.FieldNumber == 2).Data);
-                var logRecord = ReadProtobufFields(scopeLogs.Find(f => f.FieldNumber == 2).Data);
+                var logRecord = ProtobufParser.GetLogRecord(requests[0].BodyBytes);
+                var fields = logRecord.AsMessage();
+                Assert.NotEmpty(fields);
 
-                // No trace_id (field 9) or span_id (field 10) should be present
-                Assert.DoesNotContain(logRecord, f => f.FieldNumber == 9);
-                Assert.DoesNotContain(logRecord, f => f.FieldNumber == 10);
+                // trace_id (field 9) and span_id (field 10) must not be present
+                Assert.DoesNotContain(fields, f => f.FieldNumber == 9);
+                Assert.DoesNotContain(fields, f => f.FieldNumber == 10);
             }
         }
 
@@ -801,40 +700,11 @@ namespace NLog.Targets.HttpOTLP.Tests
                 var requests = server.WaitForRequests(1);
                 Assert.Single(requests);
 
-                // Decode ExportLogsServiceRequest
-                var topFields = ReadProtobufFields(requests[0].BodyBytes);
-
-                // ResourceLogs (field 1)
-                var resourceLogs = ReadProtobufFields(
-                    topFields.Find(f => f.FieldNumber == 1).Data);
-
-                // Resource (field 1 inside ResourceLogs)
-                var resourceFields = ReadProtobufFields(
-                    resourceLogs.Find(f => f.FieldNumber == 1).Data);
-
-                // Parse KeyValue list into dictionary
-                var attributes = ParseKeyValueList(resourceFields);
-
-                // Get value container
-                var valueField = attributes["service.name"];
-
-                // Decode inner StringValue message
-                var valueFields = ReadProtobufFields(valueField.Data);
-
-                // StringValue is field 1
-                var stringValueField = valueFields.Find(f => f.FieldNumber == 1);
-
-                var serviceName = Encoding.UTF8.GetString(stringValueField.Data);
-                Assert.Equal("TestService", serviceName);
+                var resourceAttributes = ProtobufParser.GetResourceAttributes(requests[0].BodyBytes);
+                Assert.Equal("TestService", resourceAttributes["service.name"].AsAnyValueString());
 
                 // Verify multiple log records exist in batch
-                var scopeLogs = ReadProtobufFields(
-                    resourceLogs.Find(f => f.FieldNumber == 2).Data);
-
-                var logRecords = scopeLogs
-                    .Where(f => f.FieldNumber == 2)
-                    .ToList();
-
+                var logRecords = ProtobufParser.GetLogRecords(requests[0].BodyBytes);
                 Assert.True(logRecords.Count >= 3);
             }
         }
@@ -861,7 +731,7 @@ namespace NLog.Targets.HttpOTLP.Tests
                     }
 
                     var requests = server.WaitForRequests(1);
-                    Assert.True(requests.Count >= 1);
+                    Assert.Single(requests);
                     Assert.Equal("/v1/logs", requests[0].Path);
                 }
                 finally
@@ -894,7 +764,7 @@ namespace NLog.Targets.HttpOTLP.Tests
                     }
 
                     var requests = server.WaitForRequests(1);
-                    Assert.True(requests.Count >= 1);
+                    Assert.Single(requests);
                     Assert.Equal("/custom/logs", requests[0].Path);
                 }
                 finally
@@ -927,7 +797,8 @@ namespace NLog.Targets.HttpOTLP.Tests
                     }
 
                     var requests = server.WaitForRequests(1);
-                    Assert.True(requests.Count >= 1);
+                    Assert.Single(requests);
+
                     Assert.True(requests[0].Headers.TryGetValue("X-Env-Header", out var envHeader));
                     Assert.Equal("envvalue", envHeader);
                     Assert.True(requests[0].Headers.TryGetValue("Authorization", out var authHeader));
@@ -962,9 +833,10 @@ namespace NLog.Targets.HttpOTLP.Tests
                     }
 
                     var requests = server.WaitForRequests(1);
-                    Assert.True(requests.Count >= 1);
-                    var bodyText = Encoding.UTF8.GetString(requests[0].BodyBytes);
-                    Assert.Contains("EnvServiceName", bodyText);
+                    Assert.Single(requests);
+
+                    var resourceAttributes = ProtobufParser.GetResourceAttributes(requests[0].BodyBytes);
+                    Assert.Equal("EnvServiceName", resourceAttributes["service.name"].AsAnyValueString());  
                 }
                 finally
                 {
@@ -995,11 +867,11 @@ namespace NLog.Targets.HttpOTLP.Tests
                     }
 
                     var requests = server.WaitForRequests(1);
-                    Assert.True(requests.Count >= 1);
-                    var bodyText = Encoding.UTF8.GetString(requests[0].BodyBytes);
-                    Assert.Contains("AttrService", bodyText);
-                    Assert.Contains("deployment.environment", bodyText);
-                    Assert.Contains("staging", bodyText);
+                    Assert.Single(requests);
+
+                    var resourceAttributes = ProtobufParser.GetResourceAttributes(requests[0].BodyBytes);
+                    Assert.Equal("AttrService", resourceAttributes["service.name"].AsAnyValueString());
+                    Assert.Equal("staging", resourceAttributes["deployment.environment"].AsAnyValueString());
                 }
                 finally
                 {
@@ -1031,10 +903,10 @@ namespace NLog.Targets.HttpOTLP.Tests
                     }
 
                     var requests = server.WaitForRequests(1);
-                    Assert.True(requests.Count >= 1);
-                    var bodyText = Encoding.UTF8.GetString(requests[0].BodyBytes);
-                    Assert.Contains("FromEnvVar", bodyText);
-                    Assert.DoesNotContain("FromAttrs", bodyText);
+                    Assert.Single(requests);
+
+                    var resourceAttributes = ProtobufParser.GetResourceAttributes(requests[0].BodyBytes);
+                    Assert.Equal("FromEnvVar", resourceAttributes["service.name"].AsAnyValueString());
                 }
                 finally
                 {
@@ -1066,12 +938,14 @@ namespace NLog.Targets.HttpOTLP.Tests
                     }
 
                     var requests = server.WaitForRequests(1);
-                    Assert.True(requests.Count >= 1);
+                    Assert.Single(requests);
                     Assert.True(requests[0].Headers.TryGetValue("Content-Encoding", out var encoding));
                     Assert.Equal("gzip", encoding);
 
-                    var decompressed = DecompressGzip(requests[0].BodyBytes);
-                    Assert.Contains("compression env test", decompressed);
+                    var decompressedBytes = DecompressGzip(requests[0].BodyBytes);
+                    var logRecord = ProtobufParser.GetLogRecord(decompressedBytes);
+                    var body = logRecord.AsMessage().GetField(5).GetField(1).AsString();
+                    Assert.Equal("compression env test", body);
                 }
                 finally
                 {
@@ -1105,7 +979,7 @@ namespace NLog.Targets.HttpOTLP.Tests
                     }
 
                     var requests = server.WaitForRequests(1);
-                    Assert.True(requests.Count >= 1);
+                    Assert.Single(requests);
 
                     // Explicit ServiceName should be used, not env var
                     var bodyText = Encoding.UTF8.GetString(requests[0].BodyBytes);
@@ -1134,86 +1008,16 @@ namespace NLog.Targets.HttpOTLP.Tests
             return logFactory;
         }
 
-        private static string DecompressGzip(byte[] compressed)
+        private static byte[] DecompressGzip(byte[] compressed)
         {
             using (var input = new MemoryStream(compressed))
             using (var gzip = new GZipStream(input, CompressionMode.Decompress))
             using (var output = new MemoryStream())
             {
                 gzip.CopyTo(output);
-                return Encoding.UTF8.GetString(output.ToArray());
+                return output.ToArray();
             }
         }
-
-        #region Protobuf Reader Helpers
-
-        private struct ProtobufField
-        {
-            public int FieldNumber;
-            public int WireType;
-            public byte[] Data;
-        }
-
-        private static List<ProtobufField> ReadProtobufFields(byte[] data)
-        {
-            var fields = new List<ProtobufField>();
-            int offset = 0;
-            while (offset < data.Length)
-            {
-                var tag = ReadVarint(data, ref offset);
-                var fieldNumber = (int)(tag >> 3);
-                var wireType = (int)(tag & 0x7);
-
-                byte[] fieldData;
-                switch (wireType)
-                {
-                    case 0: // varint
-                        var start = offset;
-                        ReadVarint(data, ref offset);
-                        fieldData = new byte[offset - start];
-                        Array.Copy(data, start, fieldData, 0, fieldData.Length);
-                        break;
-                    case 1: // 64-bit (fixed64)
-                        fieldData = new byte[8];
-                        Array.Copy(data, offset, fieldData, 0, 8);
-                        offset += 8;
-                        break;
-                    case 2: // length-delimited
-                        var length = (int)ReadVarint(data, ref offset);
-                        fieldData = new byte[length];
-                        Array.Copy(data, offset, fieldData, 0, length);
-                        offset += length;
-                        break;
-                    case 5: // 32-bit (fixed32)
-                        fieldData = new byte[4];
-                        Array.Copy(data, offset, fieldData, 0, 4);
-                        offset += 4;
-                        break;
-                    default:
-                        throw new InvalidOperationException($"Unknown protobuf wire type: {wireType}");
-                }
-
-                fields.Add(new ProtobufField { FieldNumber = fieldNumber, WireType = wireType, Data = fieldData });
-            }
-            return fields;
-        }
-
-        private static ulong ReadVarint(byte[] data, ref int offset)
-        {
-            ulong value = 0;
-            int shift = 0;
-            while (offset < data.Length)
-            {
-                var b = data[offset++];
-                value |= (ulong)(b & 0x7F) << shift;
-                if ((b & 0x80) == 0)
-                    break;
-                shift += 7;
-            }
-            return value;
-        }
-
-        #endregion
 
         private sealed class SimpleHttpServer : IDisposable
         {

--- a/tests/NLog.Targets.OpenTelemetryHttp.Tests/OtlpProtobufSerializerTests.cs
+++ b/tests/NLog.Targets.OpenTelemetryHttp.Tests/OtlpProtobufSerializerTests.cs
@@ -31,13 +31,11 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-namespace NLog.Targets.HttpOTLP.Tests
+namespace NLog.Targets.OpenTelemetryHttp.Tests
 {
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
-    using System.Text;
     using NLog.Internal;
     using Xunit;
 
@@ -46,19 +44,60 @@ namespace NLog.Targets.HttpOTLP.Tests
     /// against the OpenTelemetry OTLP logs.proto specification without requiring an HTTP server.
     /// </summary>
     /// <remarks>
-    /// Proto field references:
-    ///   ExportLogsServiceRequest { repeated ResourceLogs resource_logs = 1 }
-    ///   ResourceLogs { Resource resource = 1; repeated ScopeLogs scope_logs = 2 }
-    ///   Resource { repeated KeyValue attributes = 1 }
-    ///   ScopeLogs { InstrumentationScope scope = 1; repeated LogRecord log_records = 2 }
-    ///   InstrumentationScope { string name = 1 }
-    ///   LogRecord { fixed64 time_unix_nano = 1; SeverityNumber severity_number = 2; string severity_text = 3;
-    ///               AnyValue body = 5; repeated KeyValue attributes = 6; bytes trace_id = 9; bytes span_id = 10 }
-    ///   AnyValue { string string_value = 1; bool bool_value = 2; int64 int_value = 3; double double_value = 4;
-    ///              ArrayValue array_value = 5; KeyValueList kvlist_value = 6 }
-    ///   KeyValue { string key = 1; AnyValue value = 2 }
-    ///   ArrayValue { repeated AnyValue values = 1 }
-    ///   KeyValueList { repeated KeyValue values = 1 }
+    /// Proto field references (OTLP Logs v1):
+    ///
+    /// ExportLogsServiceRequest { repeated ResourceLogs resource_logs = 1 }
+    ///
+    /// ResourceLogs {
+    ///   Resource resource = 1;
+    ///   repeated ScopeLogs scope_logs = 2
+    /// }
+    ///
+    /// Resource {
+    ///   repeated KeyValue attributes = 1;
+    ///   uint32 dropped_attributes_count = 2
+    /// }
+    ///
+    /// ScopeLogs {
+    ///   InstrumentationScope scope = 1;
+    ///   repeated LogRecord log_records = 2
+    /// }
+    ///
+    /// InstrumentationScope {
+    ///   string name = 1
+    /// }
+    ///
+    /// LogRecord {
+    ///   fixed64 time_unix_nano = 1;
+    ///   SeverityNumber severity_number = 2 (enum);
+    ///   string severity_text = 3;
+    ///   AnyValue body = 5;
+    ///   repeated KeyValue attributes = 6;
+    ///   bytes trace_id = 9 (16 bytes);
+    ///   bytes span_id = 10 (8 bytes)
+    /// }
+    ///
+    /// AnyValue {
+    ///   string string_value = 1;
+    ///   bool bool_value = 2;
+    ///   int64 int_value = 3;
+    ///   double double_value = 4;
+    ///   ArrayValue array_value = 5;
+    ///   KeyValueList kvlist_value = 6
+    /// }
+    ///
+    /// KeyValue {
+    ///   string key = 1;
+    ///   AnyValue value = 2
+    /// }
+    ///
+    /// ArrayValue {
+    ///   repeated AnyValue values = 1
+    /// }
+    ///
+    /// KeyValueList {
+    ///   repeated KeyValue values = 1
+    /// }
     /// </remarks>
     public class OtlpProtobufSerializerTests
     {
@@ -71,18 +110,10 @@ namespace NLog.Targets.HttpOTLP.Tests
 
             var output = Serialize(serializer, LogEventInfo.Create(LogLevel.Info, "Logger", "hello"));
 
-            // Top-level message: ExportLogsServiceRequest { repeated ResourceLogs resource_logs = 1 }
-            var topFields = ReadProtobufFields(output);
-            Assert.Single(topFields);
-            var resourceLogsField = topFields[0];
-            Assert.Equal(1, resourceLogsField.FieldNumber);  // resource_logs field
-            Assert.Equal(2, resourceLogsField.WireType);     // length-delimited
+            // ExportLogsServiceRequest → ResourceLogs → ScopeLogs
+            var logRecords = ProtobufParser.GetLogRecords(output);
 
-            // ResourceLogs { Resource resource = 1; repeated ScopeLogs scope_logs = 2 }
-            var rlFields = ReadProtobufFields(resourceLogsField.Data);
-            Assert.Single(rlFields);
-            Assert.Equal(2, rlFields[0].FieldNumber); // scope_logs
-            Assert.Equal(2, rlFields[0].WireType);    // length-delimited
+            Assert.Single(logRecords);
         }
 
         [Fact]
@@ -92,46 +123,65 @@ namespace NLog.Targets.HttpOTLP.Tests
 
             var output = Serialize(serializer, LogEventInfo.Create(LogLevel.Info, "Logger", "msg"));
 
-            var scopeLogs = NavigateToScopeLogs(output);
-            var slFields = ReadProtobufFields(scopeLogs);
+            var scopeLogs = ProtobufParser.GetScopeLogs(output);
+            var slFields = scopeLogs.AsMessage();
 
             // ScopeLogs { InstrumentationScope scope = 1; repeated LogRecord log_records = 2 }
-            Assert.True(slFields.Count >= 2);
-            Assert.Equal(1, slFields[0].FieldNumber); // scope
-            Assert.Equal(2, slFields[0].WireType);
-            Assert.Equal(2, slFields[1].FieldNumber); // log_records
-            Assert.Equal(2, slFields[1].WireType);
+
+            var scopeFields = slFields.FindAll(f => f.FieldNumber == 1);
+            var logRecordFields = slFields.FindAll(f => f.FieldNumber == 2);
+
+            Assert.Single(scopeFields);        // exactly one scope message
+            Assert.NotEmpty(logRecordFields);  // at least one log record
+
+            var scopeField = scopeFields[0];
+            var logRecordField = logRecordFields[0];
+
+            Assert.Equal(2, scopeField.WireType);      // length-delimited
+            Assert.Equal(2, logRecordField.WireType);  // length-delimited
         }
 
         [Fact]
         public void Serialize_InstrumentationScope_ContainsScopeName()
         {
             var serializer = new OtlpProtobufSerializer();
-            var output = Serialize(serializer, LogEventInfo.Create(LogLevel.Info, "Logger", "msg"), scopeName: "MyInstrumentation");
+            var output = Serialize(
+                serializer,
+                LogEventInfo.Create(LogLevel.Info, "Logger", "msg"),
+                scopeName: "MyInstrumentation");
 
-            var scopeLogs = NavigateToScopeLogs(output);
-            var slFields = ReadProtobufFields(scopeLogs);
-            var scopeField = slFields.Find(f => f.FieldNumber == 1);
+            var scopeLogs = ProtobufParser.GetScopeLogs(output);
+            var slFields = scopeLogs.AsMessage();
 
-            // InstrumentationScope { string name = 1 }
-            var scopeFields = ReadProtobufFields(scopeField.Data);
-            var nameField = scopeFields.Find(f => f.FieldNumber == 1);
-            Assert.Equal(2, nameField.WireType);
-            Assert.Equal("MyInstrumentation", Encoding.UTF8.GetString(nameField.Data));
+            var scopeField = slFields.GetField(1);
+            Assert.Equal(2, scopeField.WireType);
+
+            var nameField = scopeField.GetField(1);
+            Assert.Equal("MyInstrumentation", nameField.AsString());
         }
 
         [Fact]
         public void Serialize_EmptyScopeName_OmitsScopeField()
         {
             var serializer = new OtlpProtobufSerializer();
-            var output = Serialize(serializer, LogEventInfo.Create(LogLevel.Info, "Logger", "msg"), scopeName: "");
+            var output = Serialize(
+                serializer,
+                LogEventInfo.Create(LogLevel.Info, "Logger", "msg"),
+                scopeName: "");
 
-            var scopeLogs = NavigateToScopeLogs(output);
-            var slFields = ReadProtobufFields(scopeLogs);
+            var scopeLogs = ProtobufParser.GetScopeLogs(output);
+            var slFields = scopeLogs.AsMessage();
 
-            // Without scope name only log_records (field 2) should be present
-            Assert.DoesNotContain(slFields, f => f.FieldNumber == 1);
-            Assert.Contains(slFields, f => f.FieldNumber == 2);
+            // ScopeLogs should not contain InstrumentationScope (field 1)
+            var scopeFields = slFields.FindAll(f => f.FieldNumber == 1);
+            Assert.Empty(scopeFields);
+
+            // But log_records (field 2) must still be present
+            var logRecordFields = slFields.FindAll(f => f.FieldNumber == 2);
+            Assert.NotEmpty(logRecordFields);
+
+            foreach (var lr in logRecordFields)
+                Assert.Equal(2, lr.WireType); // length-delimited
         }
 
         [Fact]
@@ -147,9 +197,8 @@ namespace NLog.Targets.HttpOTLP.Tests
             };
 
             var output = SerializeAll(serializer, logEvents);
-
-            var topFields = ReadProtobufFields(output);
-            Assert.Equal(3, topFields.FindAll(f => f.FieldNumber == 1).Count);
+            var logRecords = ProtobufParser.GetLogRecords(output);
+            Assert.Equal(3, logRecords.Count);
         }
 
         #endregion
@@ -166,15 +215,11 @@ namespace NLog.Targets.HttpOTLP.Tests
             var serializer = new OtlpProtobufSerializer();
             var output = Serialize(serializer, logEvent);
 
-            var logRecord = NavigateToLogRecord(output);
-            var lrFields = ReadProtobufFields(logRecord);
-            var timestampField = lrFields.Find(f => f.FieldNumber == 1);
+            var logRecord = ProtobufParser.GetLogRecord(output);
+            var timestampField = logRecord.AsMessage().GetField(1);
 
             // time_unix_nano = fixed64 (wire type 1), 8 bytes
-            Assert.Equal(1, timestampField.WireType);
-            Assert.Equal(8, timestampField.Data.Length);
-
-            var encodedNano = BitConverter.ToUInt64(timestampField.Data, 0);
+            var encodedNano = timestampField.AsUInt64();
             var expectedNano = OtlpProtobufSerializer.ToUnixNano(knownTime);
             Assert.Equal(expectedNano, encodedNano);
         }
@@ -186,7 +231,9 @@ namespace NLog.Targets.HttpOTLP.Tests
         [InlineData("Warn", 13)]
         [InlineData("Error", 17)]
         [InlineData("Fatal", 21)]
-        public void Serialize_LogRecord_SeverityNumberMappedCorrectly(string levelName, int expectedSeverityNumber)
+        public void Serialize_LogRecord_SeverityNumberMappedCorrectly(
+            string levelName,
+            int expectedSeverityNumber)
         {
             var level = LogLevel.FromString(levelName);
             var logEvent = LogEventInfo.Create(level, "Logger", "msg");
@@ -194,19 +241,16 @@ namespace NLog.Targets.HttpOTLP.Tests
 
             var output = Serialize(serializer, logEvent);
 
-            var logRecord = NavigateToLogRecord(output);
-            var lrFields = ReadProtobufFields(logRecord);
+            var logRecord = ProtobufParser.GetLogRecord(output);
+            var lrFields = logRecord.AsMessage();
 
-            // severity_number = field 2, varint (wire type 0)
-            var severityNumberField = lrFields.Find(f => f.FieldNumber == 2);
-            Assert.Equal(0, severityNumberField.WireType);
-            var severityNumber = (int)ReadVarintFromBytes(severityNumberField.Data);
-            Assert.Equal(expectedSeverityNumber, severityNumber);
+            // severity_number = field 2 (varint)
+            var severityNumberField = lrFields.GetField(2);
+            Assert.Equal(expectedSeverityNumber, severityNumberField.AsInt64());
 
-            // severity_text = field 3, length-delimited (wire type 2)
-            var severityTextField = lrFields.Find(f => f.FieldNumber == 3);
-            Assert.Equal(2, severityTextField.WireType);
-            Assert.Equal(levelName, Encoding.UTF8.GetString(severityTextField.Data));
+            // severity_text = field 3 (string)
+            var severityTextField = lrFields.GetField(3);
+            Assert.Equal(levelName, severityTextField.AsString());
         }
 
         [Fact]
@@ -217,17 +261,17 @@ namespace NLog.Targets.HttpOTLP.Tests
 
             var output = Serialize(serializer, logEvent);
 
-            var logRecord = NavigateToLogRecord(output);
-            var lrFields = ReadProtobufFields(logRecord);
+            var logRecord = ProtobufParser.GetLogRecord(output);
+            var lrFields = logRecord.AsMessage();
 
-            // body = field 5, AnyValue { string string_value = 1 }
-            var bodyField = lrFields.Find(f => f.FieldNumber == 5);
+            // body = field 5 (AnyValue)
+            var bodyField = lrFields.GetField(5);
             Assert.Equal(2, bodyField.WireType);
 
-            var anyValueFields = ReadProtobufFields(bodyField.Data);
-            Assert.Equal(1, anyValueFields[0].FieldNumber); // string_value
-            Assert.Equal(2, anyValueFields[0].WireType);    // length-delimited
-            Assert.Equal("hello world", Encoding.UTF8.GetString(anyValueFields[0].Data));
+            // AnyValue structure
+            var anyValue = bodyField.AsMessage();
+            var stringValueField = anyValue.GetField(1);
+            Assert.Equal("hello world", stringValueField.AsString());
         }
 
         [Fact]
@@ -238,8 +282,8 @@ namespace NLog.Targets.HttpOTLP.Tests
 
             var output = Serialize(serializer, logEvent);
 
-            var logRecord = NavigateToLogRecord(output);
-            var lrFields = ReadProtobufFields(logRecord);
+            var logRecord = ProtobufParser.GetLogRecord(output);
+            var lrFields = logRecord.AsMessage();
 
             // body (field 5) should not be present when the rendered body is empty
             Assert.DoesNotContain(lrFields, f => f.FieldNumber == 5);
@@ -253,12 +297,11 @@ namespace NLog.Targets.HttpOTLP.Tests
 
             var output = Serialize(serializer, logEvent);
 
-            var attributes = GetLogRecordAttributes(output);
-            Assert.True(attributes.TryGetValue("LoggerName", out var loggerNameValue));
+            var attributes = ProtobufParser.GetLogRecordAttributes(output);
+            Assert.True(attributes.TryGetValue("logger.name", out var loggerNameValue));
 
-            var anyValue = ReadProtobufFields(loggerNameValue.Data);
-            Assert.Equal(1, anyValue[0].FieldNumber); // string_value
-            Assert.Equal("MyApp.Service", Encoding.UTF8.GetString(anyValue[0].Data));
+            var stringValue = loggerNameValue.GetField(1).AsString();
+            Assert.Equal("MyApp.Service", stringValue);
         }
 
         [Fact]
@@ -270,19 +313,19 @@ namespace NLog.Targets.HttpOTLP.Tests
 
             var output = Serialize(serializer, logEvent);
 
-            var attributes = GetLogRecordAttributes(output);
+            var attributes = ProtobufParser.GetLogRecordAttributes(output);
 
             Assert.True(attributes.ContainsKey("exception.type"));
-            var typeAnyValue = ReadProtobufFields(attributes["exception.type"].Data);
-            Assert.Contains("InvalidOperationException", Encoding.UTF8.GetString(typeAnyValue[0].Data));
+            var typeAnyValue = attributes["exception.type"].GetField(1);
+            Assert.Contains("InvalidOperationException", typeAnyValue.AsString());
 
             Assert.True(attributes.ContainsKey("exception.message"));
-            var msgAnyValue = ReadProtobufFields(attributes["exception.message"].Data);
-            Assert.Equal("something went wrong", Encoding.UTF8.GetString(msgAnyValue[0].Data));
+            var messageAnyValue = attributes["exception.message"].GetField(1);
+            Assert.Equal("something went wrong", messageAnyValue.AsString());
 
             Assert.True(attributes.ContainsKey("exception.stacktrace"));
-            var stackAnyValue = ReadProtobufFields(attributes["exception.stacktrace"].Data);
-            Assert.Contains("InvalidOperationException", Encoding.UTF8.GetString(stackAnyValue[0].Data));
+            var stackAnyValue = attributes["exception.stacktrace"].GetField(1);
+            Assert.Contains("InvalidOperationException", stackAnyValue.AsString());
         }
 
         [Fact]
@@ -294,10 +337,11 @@ namespace NLog.Targets.HttpOTLP.Tests
 
             var output = Serialize(serializer, logEvent);
 
-            var attributes = GetLogRecordAttributes(output);
+            var attributes = ProtobufParser.GetLogRecordAttributes(output);
             Assert.True(attributes.ContainsKey("MyKey"));
-            var anyValue = ReadProtobufFields(attributes["MyKey"].Data);
-            Assert.Equal("MyValue", Encoding.UTF8.GetString(anyValue[0].Data));
+
+            var value = attributes["MyKey"].GetField(1);
+            Assert.Equal("MyValue", value.AsString());
         }
 
         [Fact]
@@ -312,8 +356,8 @@ namespace NLog.Targets.HttpOTLP.Tests
 
             var output = Serialize(serializer, logEvent);
 
-            var logRecord = NavigateToLogRecord(output);
-            var lrFields = ReadProtobufFields(logRecord);
+            var logRecord = ProtobufParser.GetLogRecord(output);
+            var lrFields = logRecord.AsMessage();
 
             // trace_id = field 9, bytes (wire type 2), exactly 16 bytes
             var traceIdField = lrFields.Find(f => f.FieldNumber == 9);
@@ -334,8 +378,8 @@ namespace NLog.Targets.HttpOTLP.Tests
 
             var output = Serialize(serializer, logEvent);
 
-            var logRecord = NavigateToLogRecord(output);
-            var lrFields = ReadProtobufFields(logRecord);
+            var logRecord = ProtobufParser.GetLogRecord(output);
+            var lrFields = logRecord.AsMessage();
 
             // span_id = field 10, bytes (wire type 2), exactly 8 bytes
             var spanIdField = lrFields.Find(f => f.FieldNumber == 10);
@@ -356,8 +400,8 @@ namespace NLog.Targets.HttpOTLP.Tests
 
             var output = Serialize(serializer, logEvent);
 
-            var logRecord = NavigateToLogRecord(output);
-            var lrFields = ReadProtobufFields(logRecord);
+            var logRecord = ProtobufParser.GetLogRecord(output);
+            var lrFields = logRecord.AsMessage();
 
             Assert.DoesNotContain(lrFields, f => f.FieldNumber == 9);
             Assert.DoesNotContain(lrFields, f => f.FieldNumber == 10);
@@ -379,14 +423,9 @@ namespace NLog.Targets.HttpOTLP.Tests
 
             var output = Serialize(serializer, LogEventInfo.Create(LogLevel.Info, "Logger", "msg"), resourceAttributes);
 
-            var resourceAttrs = GetResourceAttributes(output);
-            Assert.True(resourceAttrs.ContainsKey("deployment.environment"));
-            var envAnyValue = ReadProtobufFields(resourceAttrs["deployment.environment"].Data);
-            Assert.Equal("production", Encoding.UTF8.GetString(envAnyValue[0].Data));
-
-            Assert.True(resourceAttrs.ContainsKey("host.name"));
-            var hostAnyValue = ReadProtobufFields(resourceAttrs["host.name"].Data);
-            Assert.Equal("server01", Encoding.UTF8.GetString(hostAnyValue[0].Data));
+            var resourceAttrs = ProtobufParser.GetResourceAttributes(output);
+            Assert.Equal("production", resourceAttrs["deployment.environment"].AsAnyValueString());
+            Assert.Equal("server01", resourceAttrs["host.name"].AsAnyValueString());
         }
 
         [Fact]
@@ -405,7 +444,7 @@ namespace NLog.Targets.HttpOTLP.Tests
 
             var output = Serialize(serializer, LogEventInfo.Create(LogLevel.Info, "Logger", "msg"), resourceAttributes);
 
-            var resourceAttrs = GetResourceAttributes(output);
+            var resourceAttrs = ProtobufParser.GetResourceAttributes(output);
             Assert.True(resourceAttrs.ContainsKey("forced.attr"));
         }
 
@@ -417,106 +456,102 @@ namespace NLog.Targets.HttpOTLP.Tests
         public void AnyValue_Bool_True_EncodedAsVarintField2Value1()
         {
             var output = SerializeWithProperty("flag", true);
-            var anyValue = GetPropertyAnyValue(output, "flag");
-
-            // AnyValue { bool bool_value = 2 } → field 2, wire type 0 (varint), value 1
+            var logRecordAttributes = ProtobufParser.GetLogRecordAttributes(output);
+            var anyValue = logRecordAttributes["flag"].AsAnyValue();
             Assert.Equal(2, anyValue.FieldNumber);
-            Assert.Equal(0, anyValue.WireType);
-            Assert.Equal(1UL, ReadVarintFromBytes(anyValue.Data));
+            Assert.Equal(1, anyValue.AsInt64());
         }
 
         [Fact]
         public void AnyValue_Bool_False_EncodedAsVarintField2Value0()
         {
             var output = SerializeWithProperty("flag", false);
-            var anyValue = GetPropertyAnyValue(output, "flag");
-
+            var logRecordAttributes = ProtobufParser.GetLogRecordAttributes(output);
+            var anyValue = logRecordAttributes["flag"].AsAnyValue();
             Assert.Equal(2, anyValue.FieldNumber);
-            Assert.Equal(0, anyValue.WireType);
-            Assert.Equal(0UL, ReadVarintFromBytes(anyValue.Data));
+            Assert.Equal(0, anyValue.AsInt64());
         }
 
         [Fact]
         public void AnyValue_Int32_EncodedAsVarintField3()
         {
             var output = SerializeWithProperty("count", 42);
-            var anyValue = GetPropertyAnyValue(output, "count");
+            var logRecordAttributes = ProtobufParser.GetLogRecordAttributes(output);
+            var anyValue = logRecordAttributes["count"].AsAnyValue();
 
             // AnyValue { int64 int_value = 3 } → field 3, wire type 0 (varint)
             Assert.Equal(3, anyValue.FieldNumber);
-            Assert.Equal(0, anyValue.WireType);
-            Assert.Equal(42UL, ReadVarintFromBytes(anyValue.Data));
+            Assert.Equal(42, anyValue.AsInt64());
         }
 
         [Fact]
         public void AnyValue_NegativeInt_EncodedAsVarintField3WithZigzagTwosComplement()
         {
             var output = SerializeWithProperty("neg", -1);
-            var anyValue = GetPropertyAnyValue(output, "neg");
+            var logRecordAttributes = ProtobufParser.GetLogRecordAttributes(output);
+            var anyValue = logRecordAttributes["neg"].AsAnyValue();
 
             // Negative values use two's complement encoding (int64 → ulong cast)
             Assert.Equal(3, anyValue.FieldNumber);
-            Assert.Equal(0, anyValue.WireType);
-            var raw = ReadVarintFromBytes(anyValue.Data);
-            Assert.Equal(-1L, unchecked((long)raw));
+            Assert.Equal(-1, anyValue.AsInt64());
         }
 
         [Fact]
         public void AnyValue_UInt64_EncodedAsVarintField3()
         {
             var output = SerializeWithProperty("big", ulong.MaxValue);
-            var anyValue = GetPropertyAnyValue(output, "big");
+            var logRecordAttributes = ProtobufParser.GetLogRecordAttributes(output);
+            var anyValue = logRecordAttributes["big"].AsAnyValue();
 
             Assert.Equal(3, anyValue.FieldNumber);
-            Assert.Equal(0, anyValue.WireType);
-            Assert.Equal(ulong.MaxValue, ReadVarintFromBytes(anyValue.Data));
+            Assert.Equal(ulong.MaxValue, (ulong)anyValue.AsInt64());
         }
 
         [Fact]
         public void AnyValue_Double_EncodedAsFixed64Field4()
         {
             var output = SerializeWithProperty("ratio", 3.14);
-            var anyValue = GetPropertyAnyValue(output, "ratio");
+            var logRecordAttributes = ProtobufParser.GetLogRecordAttributes(output);
+            var anyValue = logRecordAttributes["ratio"].AsAnyValue();
 
             // AnyValue { double double_value = 4 } → field 4, wire type 1 (fixed64)
             Assert.Equal(4, anyValue.FieldNumber);
-            Assert.Equal(1, anyValue.WireType);
-            Assert.Equal(8, anyValue.Data.Length);
-            Assert.Equal(3.14, BitConverter.ToDouble(anyValue.Data, 0), precision: 10);
+            Assert.Equal(3.14, anyValue.AsDouble(), precision: 10);
         }
 
         [Fact]
         public void AnyValue_Float_EncodedAsFixed64Field4()
         {
             var output = SerializeWithProperty("f", 1.5f);
-            var anyValue = GetPropertyAnyValue(output, "f");
+            var logRecordAttributes = ProtobufParser.GetLogRecordAttributes(output);
+            var anyValue = logRecordAttributes["f"].AsAnyValue();
 
             Assert.Equal(4, anyValue.FieldNumber);
-            Assert.Equal(1, anyValue.WireType);
+            Assert.Equal(1.5f, anyValue.AsDouble());
         }
 
         [Fact]
         public void AnyValue_String_EncodedAsLengthDelimitedField1()
         {
             var output = SerializeWithProperty("msg", "hello");
-            var anyValue = GetPropertyAnyValue(output, "msg");
+            var logRecordAttributes = ProtobufParser.GetLogRecordAttributes(output);
+            var anyValue = logRecordAttributes["msg"].AsAnyValue();
 
             // AnyValue { string string_value = 1 } → field 1, wire type 2 (length-delimited)
             Assert.Equal(1, anyValue.FieldNumber);
-            Assert.Equal(2, anyValue.WireType);
-            Assert.Equal("hello", Encoding.UTF8.GetString(anyValue.Data));
+            Assert.Equal("hello", anyValue.AsString());
         }
 
         [Fact]
         public void AnyValue_Enum_EncodedAsStringField1()
         {
             var output = SerializeWithProperty("level", System.Diagnostics.TraceEventType.Warning);
-            var anyValue = GetPropertyAnyValue(output, "level");
+            var logRecordAttributes = ProtobufParser.GetLogRecordAttributes(output);
+            var anyValue = logRecordAttributes["level"].AsAnyValue();
 
             // Enums are serialized as their name string
             Assert.Equal(1, anyValue.FieldNumber);
-            Assert.Equal(2, anyValue.WireType);
-            Assert.Equal("Warning", Encoding.UTF8.GetString(anyValue.Data));
+            Assert.Equal("Warning", anyValue.AsString());
         }
 
         [Fact]
@@ -524,35 +559,33 @@ namespace NLog.Targets.HttpOTLP.Tests
         {
             var dt = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
             var output = SerializeWithProperty("ts", dt);
-            var anyValue = GetPropertyAnyValue(output, "ts");
+            var logRecordAttributes = ProtobufParser.GetLogRecordAttributes(output);
+            var anyValue = logRecordAttributes["ts"].AsAnyValue();
 
             Assert.Equal(1, anyValue.FieldNumber);
-            Assert.Equal(2, anyValue.WireType);
-            var str = Encoding.UTF8.GetString(anyValue.Data);
-            Assert.Contains("2024-01-15", str);
+            Assert.Contains("2024-01-15", anyValue.AsString());
         }
 
         [Fact]
         public void AnyValue_DoubleNaN_EncodedAsFixed64Field4()
         {
             var output = SerializeWithProperty("nan", double.NaN);
-            var anyValue = GetPropertyAnyValue(output, "nan");
+            var logRecordAttributes = ProtobufParser.GetLogRecordAttributes(output);
+            var anyValue = logRecordAttributes["nan"].AsAnyValue();
 
             Assert.Equal(4, anyValue.FieldNumber);
-            Assert.Equal(1, anyValue.WireType);
-            Assert.Equal(8, anyValue.Data.Length);
-            Assert.True(double.IsNaN(BitConverter.ToDouble(anyValue.Data, 0)));
+            Assert.True(double.IsNaN(anyValue.AsDouble()));
         }
 
         [Fact]
         public void AnyValue_DoublePositiveInfinity_EncodedAsFixed64Field4()
         {
             var output = SerializeWithProperty("inf", double.PositiveInfinity);
-            var anyValue = GetPropertyAnyValue(output, "inf");
+            var logRecordAttributes = ProtobufParser.GetLogRecordAttributes(output);
+            var anyValue = logRecordAttributes["inf"].AsAnyValue();
 
             Assert.Equal(4, anyValue.FieldNumber);
-            Assert.Equal(1, anyValue.WireType);
-            Assert.True(double.IsPositiveInfinity(BitConverter.ToDouble(anyValue.Data, 0)));
+            Assert.True(double.IsPositiveInfinity(anyValue.AsDouble()));
         }
 
         [Fact]
@@ -560,32 +593,15 @@ namespace NLog.Targets.HttpOTLP.Tests
         {
             var list = new List<object> { "alpha", 99, true };
             var output = SerializeWithProperty("items", list);
-            var anyValueWrapper = GetPropertyAnyValueWrapper(output, "items");
+            var logRecordAttributes = ProtobufParser.GetLogRecordAttributes(output);
+            var anyValueWrapper = logRecordAttributes["items"];
+            var array = anyValueWrapper.AsArrayValue();
 
-            // AnyValue { ArrayValue array_value = 5 } → field 5, wire type 2
-            var wrapperFields = ReadProtobufFields(anyValueWrapper.Data);
-            var arrayField = wrapperFields.Find(f => f.FieldNumber == 5);
-            Assert.Equal(2, arrayField.WireType);
+            Assert.Equal(3, array.Count);
 
-            // ArrayValue { repeated AnyValue values = 1 }
-            var arrayEntries = ReadProtobufFields(arrayField.Data);
-            Assert.Equal(3, arrayEntries.Count);
-            Assert.All(arrayEntries, e => Assert.Equal(1, e.FieldNumber));
-
-            // "alpha" → string_value (field 1)
-            var elem0 = ReadProtobufFields(arrayEntries[0].Data);
-            Assert.Equal(1, elem0[0].FieldNumber);
-            Assert.Equal("alpha", Encoding.UTF8.GetString(elem0[0].Data));
-
-            // 99 → int_value (field 3)
-            var elem1 = ReadProtobufFields(arrayEntries[1].Data);
-            Assert.Equal(3, elem1[0].FieldNumber);
-            Assert.Equal(99UL, ReadVarintFromBytes(elem1[0].Data));
-
-            // true → bool_value (field 2)
-            var elem2 = ReadProtobufFields(arrayEntries[2].Data);
-            Assert.Equal(2, elem2[0].FieldNumber);
-            Assert.Equal(1UL, ReadVarintFromBytes(elem2[0].Data));
+            Assert.Equal("alpha", array[0].GetField(1).AsString());
+            Assert.Equal(99L, array[1].GetField(3).AsInt64());
+            Assert.Equal(1L, array[2].GetField(2).AsInt64());
         }
 
         [Fact]
@@ -597,34 +613,13 @@ namespace NLog.Targets.HttpOTLP.Tests
                 ["key2"] = 42,
             };
             var output = SerializeWithProperty("map", dict);
-            var anyValueWrapper = GetPropertyAnyValueWrapper(output, "map");
+            var logRecordAttributes = ProtobufParser.GetLogRecordAttributes(output);
+            var anyValueWrapper = logRecordAttributes["map"];
 
             // AnyValue { KeyValueList kvlist_value = 6 } → field 6, wire type 2
-            var wrapperFields = ReadProtobufFields(anyValueWrapper.Data);
-            var kvListField = wrapperFields.Find(f => f.FieldNumber == 6);
-            Assert.Equal(2, kvListField.WireType);
-
-            // KeyValueList { repeated KeyValue values = 1 }
-            var kvEntries = ReadProtobufFields(kvListField.Data);
-            Assert.Equal(2, kvEntries.Count);
-
-            var parsed = new Dictionary<string, ProtobufField>();
-            foreach (var entry in kvEntries)
-            {
-                var entryFields = ReadProtobufFields(entry.Data);
-                var key = Encoding.UTF8.GetString(entryFields.Find(f => f.FieldNumber == 1).Data);
-                parsed[key] = entryFields.Find(f => f.FieldNumber == 2);
-            }
-
-            // key1 → string_value
-            var key1AnyValue = ReadProtobufFields(parsed["key1"].Data);
-            Assert.Equal(1, key1AnyValue[0].FieldNumber);
-            Assert.Equal("value1", Encoding.UTF8.GetString(key1AnyValue[0].Data));
-
-            // key2 → int_value
-            var key2AnyValue = ReadProtobufFields(parsed["key2"].Data);
-            Assert.Equal(3, key2AnyValue[0].FieldNumber);
-            Assert.Equal(42UL, ReadVarintFromBytes(key2AnyValue[0].Data));
+            var map = anyValueWrapper.GetField(6).AsMessage().GetFieldValues(1); // KeyValueList { repeated KeyValue values = 1 }
+            Assert.Equal("value1", map["key1"].GetField(1).AsString());
+            Assert.Equal(42L, map["key2"].GetField(3).AsInt64());
         }
 
         [Fact]
@@ -637,38 +632,22 @@ namespace NLog.Targets.HttpOTLP.Tests
             };
 
             var output = SerializeWithProperty("map", dict);
-            var anyValueWrapper = GetPropertyAnyValueWrapper(output, "map");
+            var logRecordAttributes = ProtobufParser.GetLogRecordAttributes(output);
+            var anyValueWrapper = logRecordAttributes["map"];
 
-            // AnyValue { KeyValueList kvlist_value = 6 } → field 6, wire type 2
-            var wrapperFields = ReadProtobufFields(anyValueWrapper.Data);
-            var kvListField = wrapperFields.Find(f => f.FieldNumber == 6);
-            Assert.Equal(2, kvListField.WireType);
+            // LogRecord.attributes → KeyValue.value (AnyValue)
+            // AnyValue.kvlist_value = 6 (map encoded as KeyValueList)
+            var map = anyValueWrapper.GetField(6).AsMessage().GetFieldValues(1); // KeyValueList { repeated KeyValue values = 1 }
 
-            // KeyValueList { repeated KeyValue values = 1 }
-            var kvEntries = ReadProtobufFields(kvListField.Data);
-            Assert.Equal(2, kvEntries.Count);
+            // key1 → AnyValue.string_value = 1
+            Assert.Equal("value1", map["key1"].GetField(1).AsString());
 
-            var parsed = new Dictionary<string, ProtobufField>();
-            foreach (var entry in kvEntries)
-            {
-                var entryFields = ReadProtobufFields(entry.Data);
-                var key = Encoding.UTF8.GetString(entryFields.Find(f => f.FieldNumber == 1).Data);
-                parsed[key] = entryFields.Find(f => f.FieldNumber == 2);
-            }
+            // key2 → AnyValue.array_value = 5
+            // ArrayValue contains repeated AnyValue elements (field 1)
+            var arrayEntries = map["key2"].AsArrayValue();
 
-            // key1 → string_value
-            var key1AnyValue = ReadProtobufFields(parsed["key1"].Data);
-            Assert.Equal(1, key1AnyValue[0].FieldNumber);
-            Assert.Equal("value1", Encoding.UTF8.GetString(key1AnyValue[0].Data));
-
-            // key2 → ArrayValue { ArrayValue array_value = 5 } → field 5, wire type 2
-            var key2AnyValue = ReadProtobufFields(parsed["key2"].Data);
-            var arrayField = key2AnyValue.Find(f => f.FieldNumber == 5);
-            Assert.Equal(2, arrayField.WireType);
-
-            // ArrayValue { repeated AnyValue values = 1 }
-            var arrayEntries = ReadProtobufFields(arrayField.Data);
             Assert.Equal(3, arrayEntries.Count);
+            // ArrayValue { repeated AnyValue values = 1 }
             Assert.All(arrayEntries, e => Assert.Equal(1, e.FieldNumber));
         }
 
@@ -677,27 +656,17 @@ namespace NLog.Targets.HttpOTLP.Tests
         {
             var output = SerializeWithProperty("n", (object)null);
 
-            // null is converted to empty string → WriteStringField skips it → AnyValue is omitted.
-            // The KeyValue attribute is still written (key = "n") but carries no value submessage.
-            var logRecord = NavigateToLogRecord(output);
-            var lrFields = ReadProtobufFields(logRecord);
-            var attributeFields = lrFields.FindAll(f => f.FieldNumber == 6);
+            var logRecord = ProtobufParser.GetLogRecord(output);
+            var lrFields = logRecord.AsMessage();
 
-            // Find the KeyValue whose key is "n"
-            var found = false;
-            foreach (var kv in attributeFields)
-            {
-                var kvFields = ReadProtobufFields(kv.Data);
-                var keyField = kvFields.Find(f => f.FieldNumber == 1);
-                if (keyField.Data != null && Encoding.UTF8.GetString(keyField.Data) == "n")
-                {
-                    found = true;
-                    // No value field (field 2) should be present
-                    Assert.DoesNotContain(kvFields, f => f.FieldNumber == 2);
-                    break;
-                }
-            }
-            Assert.True(found, "Attribute 'n' should be present in the log record");
+            var attributes = lrFields.GetFieldValues(6);
+
+            Assert.True(attributes.ContainsKey("n"));
+
+            // KeyValue exists, but value (field 2 inside AnyValue) should NOT exist
+            var valueField = attributes["n"];
+            Assert.Equal(0, valueField.FieldNumber);
+            Assert.Null(valueField.Data);
         }
 
         #endregion
@@ -709,8 +678,9 @@ namespace NLog.Targets.HttpOTLP.Tests
             var output = new MemoryStream();
             using (var builder = serializer.BeginRecord(output))
             {
-                var logProperties = logEvent.HasProperties ? logEvent.Properties.ToDictionary(d => d.Key.ToString(), d => d.Value) : null;
-                builder.AddScopeLogs(scopeName, logEvent, logEvent.FormattedMessage, logProperties);
+                builder.BeginScope(scopeName);
+                var logProperties = logEvent.HasProperties ? logEvent.Properties : null;
+                builder.AddLogRecord(logEvent, logEvent.FormattedMessage, logProperties);
             }
             return output.ToArray();
         }
@@ -723,8 +693,9 @@ namespace NLog.Targets.HttpOTLP.Tests
                 for (int i = 0; i < resourceAttributes.Count; i++)
                     builder.AddResourceAttribute(resourceAttributes[i].Name, resourceAttributes[i].Layout?.Render(logEvent));
 
-                var logProperties = logEvent.HasProperties ? logEvent.Properties.ToDictionary(d => d.Key.ToString(), d => d.Value) : null;
-                builder.AddScopeLogs(scopeName, logEvent, logEvent.FormattedMessage, logProperties);
+                builder.BeginScope(scopeName);
+                var logProperties = logEvent.HasProperties ? logEvent.Properties : null;
+                builder.AddLogRecord(logEvent, logEvent.FormattedMessage, logProperties);
             }
             return output.ToArray();
         }
@@ -732,12 +703,13 @@ namespace NLog.Targets.HttpOTLP.Tests
         private static byte[] SerializeAll(OtlpProtobufSerializer serializer, IList<LogEventInfo> logEvents, string scopeName = "NLog")
         {
             var output = new MemoryStream();
-            for (int i = 0; i < logEvents.Count; i++)
+            using (var builder = serializer.BeginRecord(output))
             {
-                using (var builder = serializer.BeginRecord(output))
+                builder.BeginScope(scopeName);
+                for (int i = 0; i < logEvents.Count; i++)
                 {
-                    var logProperties = logEvents[i].HasProperties ? logEvents[i].Properties.ToDictionary(d => d.Key.ToString(), d => d.Value) : null;
-                    builder.AddScopeLogs(scopeName, logEvents[i], logEvents[i].FormattedMessage, logProperties);
+                    var logProperties = logEvents[i].HasProperties ? logEvents[i].Properties : null;
+                    builder.AddLogRecord(logEvents[i], logEvents[i].FormattedMessage, logProperties);
                 }
             }
             return output.ToArray();
@@ -755,71 +727,6 @@ namespace NLog.Targets.HttpOTLP.Tests
 
         #region Protobuf navigation helpers
 
-        private static byte[] NavigateToScopeLogs(byte[] data)
-        {
-            var topFields = ReadProtobufFields(data);
-            var resourceLogs = ReadProtobufFields(topFields.Find(f => f.FieldNumber == 1).Data);
-            return resourceLogs.Find(f => f.FieldNumber == 2).Data;
-        }
-
-        private static byte[] NavigateToLogRecord(byte[] data)
-        {
-            var scopeLogs = NavigateToScopeLogs(data);
-            var slFields = ReadProtobufFields(scopeLogs);
-            return slFields.Find(f => f.FieldNumber == 2).Data;
-        }
-
-        private static Dictionary<string, ProtobufField> GetLogRecordAttributes(byte[] data)
-        {
-            var logRecord = NavigateToLogRecord(data);
-            var lrFields = ReadProtobufFields(logRecord);
-            var attributeFields = lrFields.FindAll(f => f.FieldNumber == 6);
-            return ParseKeyValueFields(attributeFields);
-        }
-
-        private static Dictionary<string, ProtobufField> GetResourceAttributes(byte[] data)
-        {
-            var topFields = ReadProtobufFields(data);
-            var resourceLogs = ReadProtobufFields(topFields.Find(f => f.FieldNumber == 1).Data);
-            var resource = ReadProtobufFields(resourceLogs.Find(f => f.FieldNumber == 1).Data);
-            var attributeFields = resource.FindAll(f => f.FieldNumber == 1);
-            return ParseKeyValueFields(attributeFields);
-        }
-
-        private static Dictionary<string, ProtobufField> ParseKeyValueFields(List<ProtobufField> keyValueFields)
-        {
-            var result = new Dictionary<string, ProtobufField>();
-            foreach (var kv in keyValueFields)
-            {
-                var fields = ReadProtobufFields(kv.Data);
-                var keyField = fields.Find(f => f.FieldNumber == 1);
-                var valueField = fields.Find(f => f.FieldNumber == 2);
-                if (keyField.Data?.Length > 0)
-                    result[Encoding.UTF8.GetString(keyField.Data)] = valueField;
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Returns the decoded inner AnyValue field (e.g. string_value=1, int_value=3) for an event property.
-        /// </summary>
-        private static ProtobufField GetPropertyAnyValue(byte[] data, string propertyKey)
-        {
-            var wrapper = GetPropertyAnyValueWrapper(data, propertyKey);
-            var anyValueFields = ReadProtobufFields(wrapper.Data);
-            return anyValueFields[0];
-        }
-
-        /// <summary>
-        /// Returns the raw AnyValue submessage field (field 2 of the KeyValue) for an event property.
-        /// </summary>
-        private static ProtobufField GetPropertyAnyValueWrapper(byte[] data, string propertyKey)
-        {
-            var attrs = GetLogRecordAttributes(data);
-            Assert.True(attrs.TryGetValue(propertyKey, out var wrapper), $"Property '{propertyKey}' not found in log record attributes");
-            return wrapper;
-        }
-
         private static string ToHex(byte[] bytes)
         {
             return BitConverter.ToString(bytes).Replace("-", "").ToLowerInvariant();
@@ -829,78 +736,11 @@ namespace NLog.Targets.HttpOTLP.Tests
 
         #region Protobuf reader helpers
 
-        private struct ProtobufField
-        {
-            public int FieldNumber;
-            public int WireType;
-            public byte[] Data;
-        }
 
-        private static List<ProtobufField> ReadProtobufFields(byte[] data)
-        {
-            var fields = new List<ProtobufField>();
-            int offset = 0;
-            while (offset < data.Length)
-            {
-                var tag = ReadVarint(data, ref offset);
-                var fieldNumber = (int)(tag >> 3);
-                var wireType = (int)(tag & 0x7);
 
-                byte[] fieldData;
-                switch (wireType)
-                {
-                    case 0: // varint
-                        var start = offset;
-                        ReadVarint(data, ref offset);
-                        fieldData = new byte[offset - start];
-                        Array.Copy(data, start, fieldData, 0, fieldData.Length);
-                        break;
-                    case 1: // 64-bit fixed
-                        fieldData = new byte[8];
-                        Array.Copy(data, offset, fieldData, 0, 8);
-                        offset += 8;
-                        break;
-                    case 2: // length-delimited
-                        var length = (int)ReadVarint(data, ref offset);
-                        fieldData = new byte[length];
-                        Array.Copy(data, offset, fieldData, 0, length);
-                        offset += length;
-                        break;
-                    case 5: // 32-bit fixed
-                        fieldData = new byte[4];
-                        Array.Copy(data, offset, fieldData, 0, 4);
-                        offset += 4;
-                        break;
-                    default:
-                        throw new InvalidOperationException($"Unknown protobuf wire type {wireType} at offset {offset}");
-                }
 
-                fields.Add(new ProtobufField { FieldNumber = fieldNumber, WireType = wireType, Data = fieldData });
-            }
-            return fields;
-        }
-
-        private static ulong ReadVarint(byte[] data, ref int offset)
-        {
-            ulong value = 0;
-            int shift = 0;
-            while (offset < data.Length)
-            {
-                var b = data[offset++];
-                value |= (ulong)(b & 0x7F) << shift;
-                if ((b & 0x80) == 0)
-                    break;
-                shift += 7;
-            }
-            return value;
-        }
-
-        private static ulong ReadVarintFromBytes(byte[] data)
-        {
-            int offset = 0;
-            return ReadVarint(data, ref offset);
-        }
 
         #endregion
     }
+
 }

--- a/tests/NLog.Targets.OpenTelemetryHttp.Tests/ProtobufParser.cs
+++ b/tests/NLog.Targets.OpenTelemetryHttp.Tests/ProtobufParser.cs
@@ -1,0 +1,254 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NLog.Targets.OpenTelemetryHttp.Tests
+{
+    internal static class ProtobufParser
+    {
+        internal struct ProtobufField
+        {
+            public int FieldNumber;
+            public int WireType;
+            public byte[] Data;
+
+            public override string ToString()
+            {
+                string value;
+
+                try
+                {
+                    switch (WireType)
+                    {
+                        case 0: value = AsInt64().ToString(); break;
+                        case 1: value = Data.Length == 8 ? AsUInt64().ToString() : null; break;
+                        case 2: value = AsMessage().Count > 0 ? $"{AsMessage().Count} Fields" : AsString(); break;
+                        case 4: value = BitConverter.ToUInt32(Data, 0).ToString(); break;
+                        default: value = $"{Data.Length} bytes"; break;
+                    };
+                }
+                catch
+                {
+                    value = WireType == 2 ? AsString() : $"{Data.Length} bytes";
+                }
+
+                return $"Field {FieldNumber} (WireType={WireType}, Value={value})";
+            }
+
+            public string AsString()
+            {
+                EnsureWireType(2);
+                return Encoding.UTF8.GetString(Data);
+            }
+
+            public List<ProtobufField> AsMessage()
+            {
+                EnsureWireType(2);
+                return ReadProtobufFields(Data);
+            }
+
+            public ProtobufField AsAnyValue()
+            {
+                var fields = AsMessage();
+                if (fields.Count != 1)
+                    throw new InvalidOperationException($"AnyValue expected exactly 1 field, got {fields.Count} for Field {FieldNumber}");
+
+                var value = fields[0];
+                // 1 = string, 2 = bool, 3 = int, 4 = double, 5 = array, 6 = kvlist
+                if (value.FieldNumber < 1 || value.FieldNumber > 6)
+                    throw new InvalidOperationException($"Invalid AnyValue field {value.FieldNumber} in Field {FieldNumber}");
+                return value;
+            }
+
+            public string AsAnyValueString()
+            {
+                var value = AsAnyValue();
+                if (value.FieldNumber != 1)
+                    throw new InvalidOperationException($"Expected AnyValue.string_value (field 1), but found field {value.FieldNumber}");
+                return value.AsString();
+            }
+
+            public long AsInt64()
+            {
+                EnsureWireType(0);
+                int offset = 0;
+                return (long)ReadVarint(Data, ref offset);
+            }
+
+            public ulong AsUInt64()
+            {
+                EnsureWireType(1); // fixed64
+                EnsureDataLength(8);
+                return BitConverter.ToUInt64(Data, 0);
+            }
+
+            public double AsDouble()
+            {
+                EnsureWireType(1);  // fixed64
+                EnsureDataLength(8);
+                return BitConverter.ToDouble(Data, 0);
+            }
+
+            public ProtobufField GetField(int fieldNumber) => ProtobufExtensions.GetField(AsMessage(), fieldNumber);
+            public List<ProtobufField> AsArrayValue() => GetField(5).AsMessage();
+
+            private void EnsureWireType(int expected)
+            {
+                if (WireType != expected)
+                    throw new InvalidOperationException(
+                        $"Expected wire type {expected}, got {WireType} for Field {FieldNumber}");
+            }
+
+            private void EnsureDataLength(int expected)
+            {
+                if (Data.Length != expected)
+                    throw new InvalidOperationException(
+                        $"Expected data length {expected}, got {Data.Length} for Field {FieldNumber}");
+            }
+        }
+
+        public static ProtobufField GetScopeLogs(byte[] data)
+        {
+            var resourceLogs = ReadProtobufFields(data).GetField(1);
+            var scopeLogs = resourceLogs.GetField(2);
+            if (scopeLogs.WireType != 2)
+                throw new InvalidOperationException($"ScopeLogs must be length-delimited (wire type 2), got {scopeLogs.WireType}");
+            return scopeLogs;
+        }
+
+        public static ProtobufField GetLogRecord(byte[] data)
+        {
+            var logRecord = GetLogRecords(data).GetField(2);
+            if (logRecord.WireType != 2)
+                throw new InvalidOperationException($"LogRecord must be length-delimited (wire type 2), got {logRecord.WireType}");
+            return logRecord;
+        }
+
+        public static List<ProtobufField> GetLogRecords(byte[] data)
+        {
+            var logRecords = GetScopeLogs(data).AsMessage().Where(f => f.FieldNumber == 2).ToList();
+            foreach (var logRecord in logRecords)
+            {
+                if (logRecord.WireType != 2)
+                    throw new InvalidOperationException($"LogRecord must be length-delimited (wire type 2), got {logRecord.WireType}");
+            }
+            return logRecords;
+        }
+
+        internal static Dictionary<string, ProtobufField> GetLogRecordAttributes(byte[] data)
+        {
+            var logRecord = GetLogRecord(data).AsMessage();
+            return logRecord.GetFieldValues(6);
+        }
+
+        internal static Dictionary<string, ProtobufField> GetResourceAttributes(byte[] data)
+        {
+            var resourceLogs = ReadProtobufFields(data).GetField(1);
+            var resource = resourceLogs.GetField(1).AsMessage();
+            return resource.GetFieldValues(1);  // Resource.attributes
+        }
+
+        private static List<ProtobufField> ReadProtobufFields(byte[] data)
+        {
+            var fields = new List<ProtobufField>();
+            int offset = 0;
+            while (offset < data.Length)
+            {
+                ulong tag = ReadVarint(data, ref offset);
+                int fieldNumber = (int)(tag >> 3);
+                int wireType = (int)(tag & 0x7);
+
+                byte[] fieldData;
+                switch (wireType)
+                {
+                    case 0: // varint
+                        var start = offset;
+                        ReadVarint(data, ref offset);
+                        fieldData = new byte[offset - start];
+                        Array.Copy(data, start, fieldData, 0, fieldData.Length);
+                        break;
+                    case 1: // 64-bit fixed
+                        fieldData = new byte[8];
+                        Array.Copy(data, offset, fieldData, 0, 8);
+                        offset += 8;
+                        break;
+                    case 2: // length-delimited
+                        var length = (int)ReadVarint(data, ref offset);
+                        fieldData = new byte[length];
+                        Array.Copy(data, offset, fieldData, 0, length);
+                        offset += length;
+                        break;
+                    case 5: // 32-bit fixed
+                        fieldData = new byte[4];
+                        Array.Copy(data, offset, fieldData, 0, 4);
+                        offset += 4;
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unknown protobuf wire type {wireType} at offset {offset}");
+                }
+
+                fields.Add(new ProtobufField { FieldNumber = fieldNumber, WireType = wireType, Data = fieldData });
+            }
+            return fields;
+        }
+
+        private static ulong ReadVarint(byte[] data, ref int offset)
+        {
+            ulong value = 0;
+            int shift = 0;
+            while (offset < data.Length)
+            {
+                byte b = data[offset++];
+                value |= (ulong)(b & 0x7F) << shift;
+                if ((b & 0x80) == 0)
+                    break;
+                shift += 7;
+            }
+            return value;
+        }
+    }
+
+    internal static class ProtobufExtensions
+    {
+        internal static ProtobufParser.ProtobufField GetField(this List<ProtobufParser.ProtobufField> fields, int fieldNumber)
+        {
+            ProtobufParser.ProtobufField? match = null;
+            foreach (var field in fields)
+            {
+                if (field.FieldNumber == fieldNumber)
+                {
+                    if (match != null)
+                        throw new InvalidOperationException($"Multiple fields with number {fieldNumber} found");
+                    match = field;
+                }
+            }
+            if (match == null)
+                throw new InvalidOperationException($"Field with number {fieldNumber} not found");
+            return match.Value;
+        }
+
+        public static Dictionary<string, ProtobufParser.ProtobufField> GetFieldValues(this List<ProtobufParser.ProtobufField> fields, int fieldNumber)
+        {
+            var result = new Dictionary<string, ProtobufParser.ProtobufField>();
+            foreach (var field in fields)
+            {
+                if (field.FieldNumber != fieldNumber)
+                    continue;
+
+                if (field.WireType != 2)
+                    throw new InvalidOperationException(
+                        $"Expected KeyValue to be length-delimited (wire type 2), got {field.WireType}");
+
+                var kvFields = field.AsMessage();
+                var key = kvFields.GetField(1).AsString();
+                if (string.IsNullOrWhiteSpace(key))
+                    throw new InvalidOperationException("Key is empty");
+
+                var valueField = kvFields.Find(f => f.FieldNumber == 2);
+                result.Add(key, valueField);
+            }
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Single ScopeLogs + ResourceLogs for each batch of LogRecords (Reduce http-payload-size)

Include same resource-attributes for every batch:
- service.name - ${appdomain:format=Friendly}
- service.version - ${assembly-version:Default=}
- host.name - ${hostname}
- process.id - ${processid}
- os.type - windows / linux / unknown
- telemetry.sdk.language  - dotnet
- telemetry.sdk.name - NLog.Targets.OpenTelemetryHttpTarget
- telemetry.sdk.version  - 6.0.0

Include LogRecord-attributes, when possible:
- logger.name - LogEventInfo.LoggerName
- event.id - LogEventInfo.Properties["EventId"]
- event.name - LogEventInfo.Properties["EventName"]
- log.record.original - MessageTemplate - LogEventInfo.Message

Hopefully Preview2 will give a better out-of-the-box-experience.