### PR TITLE
Recreate HttpClient when rendered URL changes

### DIFF
--- a/src/NLog.Targets.HttpClient/HttpClientTarget.cs
+++ b/src/NLog.Targets.HttpClient/HttpClientTarget.cs
@@ -371,13 +371,14 @@ namespace NLog.Targets
             try
             {
                 int lastBatchSize = 0;
+                var baseUrl = RenderBaseUrl(logEvents[0]);
                 var httpContent = Compress == HttpCompressionType.None ? BuildChunk(output, logEvents, 0, out lastBatchSize) : GZipCompressChunk(output, logEvents, 0, out lastBatchSize);
                 {
-                    using var _ = await HttpClientSendAsync(null, httpContent, cancellationToken).ConfigureAwait(false);
+                    using var _ = await HttpClientSendAsync(baseUrl, httpContent, cancellationToken).ConfigureAwait(false);
                 }
                 if (lastBatchSize != logEvents.Count)
                 {
-                    await HttpSendBatchesAsync(output, lastBatchSize, logEvents, cancellationToken).ConfigureAwait(false);
+                    await HttpSendBatchesAsync(baseUrl, output, lastBatchSize, logEvents, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch
@@ -399,14 +400,14 @@ namespace NLog.Targets
             oldStream.Dispose();
         }
 
-        private async Task HttpSendBatchesAsync(MemoryStream output, int lastBatchSize, IList<LogEventInfo> logEvents, CancellationToken cancellationToken)
+        private async Task HttpSendBatchesAsync(Uri baseUrl, MemoryStream output, int lastBatchSize, IList<LogEventInfo> logEvents, CancellationToken cancellationToken)
         {
             int batchStartIndex = lastBatchSize;
             while (batchStartIndex < logEvents.Count)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var httpContent = Compress == HttpCompressionType.None ? BuildChunk(output, logEvents, batchStartIndex, out lastBatchSize) : GZipCompressChunk(output, logEvents, batchStartIndex, out lastBatchSize);
-                using var _ = await HttpClientSendAsync(null, httpContent, cancellationToken).ConfigureAwait(false);
+                using var _ = await HttpClientSendAsync(baseUrl, httpContent, cancellationToken).ConfigureAwait(false);
                 batchStartIndex += lastBatchSize;
             }
         }
@@ -617,15 +618,33 @@ namespace NLog.Targets
             }
         }
 
-        private HttpClient ResetHttpClientIfNeeded(Uri? url)
+        private Uri RenderBaseUrl(LogEventInfo logEventInfo)
+        {
+            var lastRenderedBaseUri = _lastRenderedBaseUri;
+
+            var baseUrl = RenderLogEvent(Url, logEventInfo);
+            if (string.IsNullOrEmpty(baseUrl))
+                throw new NLogRuntimeException($"Invalid {nameof(Url)} specified for {GetType()}: {baseUrl}");
+
+            if (lastRenderedBaseUri != null && string.Equals(lastRenderedBaseUri.Item1, baseUrl, StringComparison.Ordinal))
+                return lastRenderedBaseUri.Item2;
+
+            if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri))
+                throw new NLogRuntimeException($"Invalid {nameof(Url)} specified for {GetType()}: {baseUrl}");
+
+            _lastRenderedBaseUri = new Tuple<string, Uri>(baseUrl, uri);
+            return uri;
+        }
+        private Tuple<string, Uri>? _lastRenderedBaseUri = null;
+
+        private HttpClient ResetHttpClientIfNeeded(Uri? baseUrl)
         {
             var oldHttpClient = _httpClient;
-            var baseAddressUri = GetBaseAddressUri(url);
 
             int nowTickCount = Environment.TickCount;
             if (!HttpClientLifeTimeExpired(nowTickCount, _httpClientLifeTimeTicks) && oldHttpClient != null)
             {
-                if (Equals(oldHttpClient.BaseAddress, baseAddressUri))
+                if (baseUrl is null || oldHttpClient.BaseAddress.Equals(baseUrl))
                     return oldHttpClient;
             }
 
@@ -633,12 +652,12 @@ namespace NLog.Targets
             lock (_reusableEncodingBuffer)
             {
                 oldHttpClient = _httpClient;
-                if (!HttpClientLifeTimeExpired(nowTickCount, _httpClientLifeTimeTicks) && oldHttpClient != null && Equals(oldHttpClient.BaseAddress, baseAddressUri))
+                if (!HttpClientLifeTimeExpired(nowTickCount, _httpClientLifeTimeTicks) && oldHttpClient != null && (baseUrl is null || oldHttpClient.BaseAddress.Equals(baseUrl)))
                     return oldHttpClient;
 
                 _httpClient = null;
                 oldHttpClient?.Dispose();
-                _httpClient = oldHttpClient = CreateNewHttpClient(baseAddressUri);
+                _httpClient = oldHttpClient = CreateNewHttpClient(baseUrl);
                 _httpClientCreatedTicks = nowTickCount;
             }
 
@@ -661,26 +680,22 @@ namespace NLog.Targets
             }
         }
 
-        private Uri GetBaseAddressUri(Uri? url)
-        {
-            if (url != null)
-                return url;
-
-            var nullEvent = LogEventInfo.CreateNullEvent();
-            var baseAddress = Url?.Render(nullEvent);
-            if (!Uri.TryCreate(baseAddress, UriKind.Absolute, out var baseAddressUri))
-                throw new NLogRuntimeException($"Invalid {nameof(Url)} specified for {GetType()}: {baseAddress}");
-            return baseAddressUri;
-        }
-
-        private HttpClient CreateNewHttpClient(Uri baseAddressUri)
+        private HttpClient CreateNewHttpClient(Uri? baseUrl)
         {
             var nullEvent = LogEventInfo.CreateNullEvent();
 
+            var baseAddress = baseUrl?.ToString() ?? Url?.Render(nullEvent);
             if (_httpClientCreatedTicks == 0)
-                NLog.Common.InternalLogger.Info("{0}: Creating HttpClient for BaseAddress: {1}", this, baseAddressUri);
+                NLog.Common.InternalLogger.Info("{0}: Creating HttpClient for BaseAddress: {1}", this, baseAddress);
             else
-                NLog.Common.InternalLogger.Debug("{0}: Creating HttpClient for BaseAddress: {1}", this, baseAddressUri);
+                NLog.Common.InternalLogger.Debug("{0}: Creating HttpClient for BaseAddress: {1}", this, baseAddress);
+
+            if (baseUrl is null)
+            {
+                if (!Uri.TryCreate(baseAddress, UriKind.Absolute, out var baseAddressUri))
+                    throw new NLogRuntimeException($"Invalid {nameof(Url)} specified for {GetType()}: {baseAddress}");
+                baseUrl = baseAddressUri;
+            }
 
             var handler = new HttpClientHandler();
 
@@ -751,7 +766,7 @@ namespace NLog.Targets
 
             var newHttpClient = new HttpClient(handler)
             {
-                BaseAddress = baseAddressUri,
+                BaseAddress = baseUrl,
             };
             if (SendTimeoutSeconds > 0)
                 newHttpClient.Timeout = TimeSpan.FromSeconds(SendTimeoutSeconds);

--- a/src/NLog.Targets.HttpClient/HttpClientTarget.cs
+++ b/src/NLog.Targets.HttpClient/HttpClientTarget.cs
@@ -620,11 +620,12 @@ namespace NLog.Targets
         private HttpClient ResetHttpClientIfNeeded(Uri? url)
         {
             var oldHttpClient = _httpClient;
+            var baseAddressUri = GetBaseAddressUri(url);
 
             int nowTickCount = Environment.TickCount;
             if (!HttpClientLifeTimeExpired(nowTickCount, _httpClientLifeTimeTicks) && oldHttpClient != null)
             {
-                if (url is null || oldHttpClient.BaseAddress.Equals(url))
+                if (Equals(oldHttpClient.BaseAddress, baseAddressUri))
                     return oldHttpClient;
             }
 
@@ -632,12 +633,12 @@ namespace NLog.Targets
             lock (_reusableEncodingBuffer)
             {
                 oldHttpClient = _httpClient;
-                if (!HttpClientLifeTimeExpired(nowTickCount, _httpClientLifeTimeTicks) && oldHttpClient != null && (url is null || oldHttpClient.BaseAddress.Equals(url)))
+                if (!HttpClientLifeTimeExpired(nowTickCount, _httpClientLifeTimeTicks) && oldHttpClient != null && Equals(oldHttpClient.BaseAddress, baseAddressUri))
                     return oldHttpClient;
 
                 _httpClient = null;
                 oldHttpClient?.Dispose();
-                _httpClient = oldHttpClient = CreateNewHttpClient(url);
+                _httpClient = oldHttpClient = CreateNewHttpClient(baseAddressUri);
                 _httpClientCreatedTicks = nowTickCount;
             }
 
@@ -660,17 +661,26 @@ namespace NLog.Targets
             }
         }
 
-        private HttpClient CreateNewHttpClient(Uri? url)
+        private Uri GetBaseAddressUri(Uri? url)
+        {
+            if (url != null)
+                return url;
+
+            var nullEvent = LogEventInfo.CreateNullEvent();
+            var baseAddress = Url?.Render(nullEvent);
+            if (!Uri.TryCreate(baseAddress, UriKind.Absolute, out var baseAddressUri))
+                throw new NLogRuntimeException($"Invalid {nameof(Url)} specified for {GetType()}: {baseAddress}");
+            return baseAddressUri;
+        }
+
+        private HttpClient CreateNewHttpClient(Uri baseAddressUri)
         {
             var nullEvent = LogEventInfo.CreateNullEvent();
 
-            var baseAddress = url?.ToString() ?? Url?.Render(nullEvent);
             if (_httpClientCreatedTicks == 0)
-                NLog.Common.InternalLogger.Info("{0}: Creating HttpClient for BaseAddress: {1}", this, baseAddress);
+                NLog.Common.InternalLogger.Info("{0}: Creating HttpClient for BaseAddress: {1}", this, baseAddressUri);
             else
-                NLog.Common.InternalLogger.Debug("{0}: Creating HttpClient for BaseAddress: {1}", this, baseAddress);
-            if (!Uri.TryCreate(baseAddress, UriKind.Absolute, out var baseAddressUri))
-                throw new NLogRuntimeException($"Invalid {nameof(Url)} specified for {GetType()}: {baseAddress}");
+                NLog.Common.InternalLogger.Debug("{0}: Creating HttpClient for BaseAddress: {1}", this, baseAddressUri);
 
             var handler = new HttpClientHandler();
 

--- a/tests/NLog.Targets.HttpClient.Tests/HttpClientTargetTests.cs
+++ b/tests/NLog.Targets.HttpClient.Tests/HttpClientTargetTests.cs
@@ -249,6 +249,54 @@ namespace NLog.Targets.HttpClient.Tests
         }
 
         [Fact]
+        public void UrlLayoutChange_RecreatesHttpClientForNewRenderedUrl()
+        {
+            using (var firstServer = new SimpleHttpServer())
+            using (var secondServer = new SimpleHttpServer())
+            {
+                const string gdcKey = "HttpClientTargetTests_LogUrl";
+                try
+                {
+                    GlobalDiagnosticsContext.Set(gdcKey, $"http://127.0.0.1:{firstServer.Port}");
+
+                    var target = new HttpClientTarget
+                    {
+                        Url = $"${{gdc:item={gdcKey}}}/logs",
+                        Layout = "${message}",
+                        RetryCount = 0,
+                        TaskDelayMilliseconds = 1,
+                    };
+
+                    using (var logFactory = BuildLogFactory(target))
+                    {
+                        logFactory.ThrowExceptions = false;
+                        var logger = logFactory.GetLogger("TestLogger");
+
+                        logger.Info("first");
+                        logFactory.Flush();
+
+                        var firstRequests = firstServer.WaitForRequests(1);
+                        Assert.Single(firstRequests);
+                        Assert.Equal("first", firstRequests[0].Body);
+
+                        GlobalDiagnosticsContext.Set(gdcKey, $"http://127.0.0.1:{secondServer.Port}");
+
+                        logger.Info("second");
+                        logFactory.Flush();
+
+                        var secondRequests = secondServer.WaitForRequests(1, 1000);
+                        Assert.Single(secondRequests);
+                        Assert.Equal("second", secondRequests[0].Body);
+                    }
+                }
+                finally
+                {
+                    GlobalDiagnosticsContext.Remove(gdcKey);
+                }
+            }
+        }
+
+        [Fact]
         public void MaxPayloadSizeBytes_SplitsLargeBatchIntoMultipleRequests()
         {
             using (var server = new SimpleHttpServer())


### PR DESCRIPTION
Summary:
- Re-render the target URL before reusing the cached HttpClient.
- Recreate the client when the rendered BaseAddress changes.
- Add a regression test for layout-based URL changes.

Tests:
- dotnet test tests/NLog.Targets.HttpClient.Tests/NLog.Targets.HttpClient.Tests.csproj --no-restore --framework net10.0

Transparency:
- AI assistance was used to prepare this change.